### PR TITLE
test(todo-cli): add failing tests for persistence, IDs, and CLI parsing

### DIFF
--- a/todo-cli/cmd/todo-cli/main.go
+++ b/todo-cli/cmd/todo-cli/main.go
@@ -1,0 +1,16 @@
+package main
+
+import "errors"
+
+var ErrUnknownCommand = errors.New("unknown command")
+
+type Command struct {
+	Name string
+	Args []string
+}
+
+func ParseCommand(args []string) (Command, error) {
+	return Command{}, ErrUnknownCommand
+}
+
+func main() {}

--- a/todo-cli/cmd/todo-cli/main_test.go
+++ b/todo-cli/cmd/todo-cli/main_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type commandTestCase struct {
+	name    string
+	args    []string
+	want    Command
+	wantErr error
+}
+
+func TestParseCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "tasks.json")
+
+	cases := []commandTestCase{
+		{
+			name: "add task",
+			args: []string{"todo-cli", "add", "write tests"},
+			want: Command{Name: "add", Args: []string{"write tests"}},
+		},
+		{
+			name: "list tasks",
+			args: []string{"todo-cli", "list"},
+			want: Command{Name: "list"},
+		},
+		{
+			name: "mark done",
+			args: []string{"todo-cli", "done", "2"},
+			want: Command{Name: "done", Args: []string{"2"}},
+		},
+		{
+			name: "remove task",
+			args: []string{"todo-cli", "rm", "1"},
+			want: Command{Name: "rm", Args: []string{"1"}},
+		},
+		{
+			name: "clear tasks",
+			args: []string{"todo-cli", "clear"},
+			want: Command{Name: "clear"},
+		},
+		{
+			name:    "unknown command",
+			args:    []string{"todo-cli", "bogus"},
+			wantErr: ErrUnknownCommand,
+		},
+		{
+			name:    "done without id",
+			args:    []string{"todo-cli", "done"},
+			wantErr: ErrUnknownCommand,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Args = append([]string(nil), tc.args...)
+			cmd, err := ParseCommand(os.Args)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+			if err != nil {
+				return
+			}
+			if cmd.Name != tc.want.Name {
+				t.Fatalf("expected command name %q, got %q", tc.want.Name, cmd.Name)
+			}
+			if fmt.Sprint(cmd.Args) != fmt.Sprint(tc.want.Args) {
+				t.Fatalf("expected args %v, got %v", tc.want.Args, cmd.Args)
+			}
+		})
+	}
+
+	// ensure parse respects default storage path flag even when unused
+	os.Args = []string{"todo-cli", "list", "--storage", tmpFile}
+	cmd, err := ParseCommand(os.Args)
+	if err != nil {
+		t.Fatalf("unexpected error parsing storage flag: %v", err)
+	}
+	if cmd.Name != "list" {
+		t.Fatalf("expected list command when parsing storage flag, got %q", cmd.Name)
+	}
+	if len(cmd.Args) != 1 || cmd.Args[0] != tmpFile {
+		t.Fatalf("expected storage path in args, got %v", cmd.Args)
+	}
+}

--- a/todo-cli/go.mod
+++ b/todo-cli/go.mod
@@ -1,4 +1,5 @@
 module github.com/pekomon/go-sandbox/todo-cli
 
 go 1.24
+
 toolchain go1.24.3

--- a/todo-cli/internal/storage/storage.go
+++ b/todo-cli/internal/storage/storage.go
@@ -1,0 +1,11 @@
+package storage
+
+import "github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+
+func LoadTasks(path string) ([]tasks.Task, error) {
+	return nil, nil
+}
+
+func SaveTasks(path string, taskList []tasks.Task) error {
+	return nil
+}

--- a/todo-cli/internal/storage/storage_test.go
+++ b/todo-cli/internal/storage/storage_test.go
@@ -1,0 +1,65 @@
+package storage_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/todo-cli/internal/storage"
+	"github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+)
+
+func TestSaveAndLoadTasks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.json")
+
+	want := []tasks.Task{
+		{ID: 1, Text: "write tests"},
+		{ID: 2, Text: "implement features", Done: true},
+	}
+
+	if err := storage.SaveTasks(path, want); err != nil {
+		t.Fatalf("SaveTasks returned error: %v", err)
+	}
+
+	got, err := storage.LoadTasks(path)
+	if err != nil {
+		t.Fatalf("LoadTasks returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("loaded tasks mismatch\nwant: %#v\ngot:  %#v", want, got)
+	}
+}
+
+func TestLoadTasksWithCorruptedJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.json")
+
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatalf("failed to write corrupted file: %v", err)
+	}
+
+	if _, err := storage.LoadTasks(path); err == nil {
+		t.Fatalf("expected error when loading corrupted JSON")
+	}
+}
+
+func TestLoadTasksFromEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.json")
+
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("failed to create empty file: %v", err)
+	}
+
+	tasks, err := storage.LoadTasks(path)
+	if err != nil {
+		t.Fatalf("LoadTasks returned error: %v", err)
+	}
+
+	if len(tasks) != 0 {
+		t.Fatalf("expected no tasks, got %d", len(tasks))
+	}
+}

--- a/todo-cli/internal/tasks/tasks.go
+++ b/todo-cli/internal/tasks/tasks.go
@@ -1,0 +1,27 @@
+package tasks
+
+import "errors"
+
+var ErrTaskNotFound = errors.New("task not found")
+
+type Task struct {
+	ID   int
+	Text string
+	Done bool
+}
+
+func Add(taskList []Task, text string) []Task {
+	return nil
+}
+
+func MarkDone(taskList []Task, id int) ([]Task, error) {
+	return nil, ErrTaskNotFound
+}
+
+func Remove(taskList []Task, id int) ([]Task, error) {
+	return nil, ErrTaskNotFound
+}
+
+func Sort(taskList []Task, reverse bool) []Task {
+	return nil
+}

--- a/todo-cli/internal/tasks/tasks_test.go
+++ b/todo-cli/internal/tasks/tasks_test.go
@@ -1,0 +1,93 @@
+package tasks_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+)
+
+func TestAddAssignsSequentialIDs(t *testing.T) {
+	list := []tasks.Task{}
+
+	list = tasks.Add(list, "write tests")
+	list = tasks.Add(list, "implement features")
+	list = tasks.Add(list, "ship it")
+
+	if len(list) != 3 {
+		t.Fatalf("expected 3 tasks, got %d", len(list))
+	}
+
+	for i, task := range list {
+		wantID := i + 1
+		if task.ID != wantID {
+			t.Fatalf("task %q expected ID %d, got %d", task.Text, wantID, task.ID)
+		}
+	}
+}
+
+func TestMarkDoneUpdatesStatus(t *testing.T) {
+	list := []tasks.Task{}
+	list = tasks.Add(list, "write tests")
+	list = tasks.Add(list, "implement features")
+
+	updated, err := tasks.MarkDone(list, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !updated[1].Done {
+		t.Fatalf("expected task 2 to be marked done")
+	}
+
+	if updated[0].Done {
+		t.Fatalf("expected task 1 to remain not done")
+	}
+
+	_, err = tasks.MarkDone(list, 99)
+	if !errors.Is(err, tasks.ErrTaskNotFound) {
+		t.Fatalf("expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestRemoveDeletesTask(t *testing.T) {
+	list := []tasks.Task{}
+	list = tasks.Add(list, "write tests")
+	list = tasks.Add(list, "implement features")
+
+	updated, err := tasks.Remove(list, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(updated) != 1 {
+		t.Fatalf("expected 1 task remaining, got %d", len(updated))
+	}
+
+	if updated[0].ID != 2 {
+		t.Fatalf("expected remaining task to have ID 2, got %d", updated[0].ID)
+	}
+
+	_, err = tasks.Remove(list, 99)
+	if !errors.Is(err, tasks.ErrTaskNotFound) {
+		t.Fatalf("expected ErrTaskNotFound, got %v", err)
+	}
+}
+
+func TestSortOrdersByNewestAndReverse(t *testing.T) {
+	list := []tasks.Task{
+		{ID: 1, Text: "first"},
+		{ID: 2, Text: "second"},
+		{ID: 3, Text: "third"},
+	}
+
+	sorted := tasks.Sort(list, false)
+	if sorted[0].ID != 3 || sorted[1].ID != 2 || sorted[2].ID != 1 {
+		t.Fatalf("expected newest-first order, got %+v", sorted)
+	}
+
+	reversed := tasks.Sort(list, true)
+	if reversed[0].ID != 1 || reversed[1].ID != 2 || reversed[2].ID != 3 {
+		t.Fatalf("expected ascending order when reverse flag set, got %+v", reversed)
+	}
+}


### PR DESCRIPTION
Adds tests only (no implementation) for the todo-cli module.
Covers JSON persistence, ID assignment, and command parsing (add, list, done <id>, rm <id>, clear).
Uses only the Go standard library (no external deps).
Tests fail initially until the feature is implemented.
**Closes #2.**

------
https://chatgpt.com/codex/tasks/task_b_68e3f9c20968832fbc69bcf4582729dd