### PR TITLE
feat(todo-cli): implement CLI, storage, and task logic to pass tests

### DIFF
--- a/todo-cli/cmd/todo-cli/main.go
+++ b/todo-cli/cmd/todo-cli/main.go
@@ -1,6 +1,16 @@
 package main
 
-import "errors"
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pekomon/go-sandbox/todo-cli/internal/storage"
+	"github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+)
 
 var ErrUnknownCommand = errors.New("unknown command")
 
@@ -9,8 +19,233 @@ type Command struct {
 	Args []string
 }
 
+// ParseCommand inspects the provided CLI arguments (including program name) and
+// returns the parsed command. It keeps support for the legacy command parsing
+// API used in older tests.
 func ParseCommand(args []string) (Command, error) {
-	return Command{}, ErrUnknownCommand
+	if len(args) < 2 {
+		return Command{}, ErrUnknownCommand
+	}
+	cmd := Command{Name: args[1]}
+	rest := args[2:]
+	var storagePath string
+	filtered := make([]string, 0, len(rest))
+	for i := 0; i < len(rest); i++ {
+		s := rest[i]
+		if s == "--storage" {
+			if i+1 >= len(rest) {
+				return Command{}, ErrUnknownCommand
+			}
+			storagePath = rest[i+1]
+			i++
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	switch cmd.Name {
+	case "add":
+		if len(filtered) == 0 {
+			return Command{}, ErrUnknownCommand
+		}
+		cmd.Args = []string{strings.Join(filtered, " ")}
+	case "list":
+		if storagePath != "" {
+			cmd.Args = append(cmd.Args, storagePath)
+		}
+		cmd.Args = append(cmd.Args, filtered...)
+	case "done", "rm":
+		if len(filtered) != 1 {
+			return Command{}, ErrUnknownCommand
+		}
+		cmd.Args = filtered
+		if storagePath != "" {
+			cmd.Args = append(cmd.Args, storagePath)
+		}
+	case "clear":
+		if len(filtered) != 0 {
+			return Command{}, ErrUnknownCommand
+		}
+		if storagePath != "" {
+			cmd.Args = []string{storagePath}
+		}
+	default:
+		return Command{}, ErrUnknownCommand
+	}
+	return cmd, nil
 }
 
-func main() {}
+// Run is separated for testability. Returns exit code.
+func Run(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: todo-cli <add|list|done|rm|clear> [args]")
+		return 2
+	}
+
+	// Resolve storage path
+	jsonPath, err := storage.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error resolving storage path:", err)
+		return 1
+	}
+
+	// Commands
+	switch args[0] {
+	case "add":
+		text := strings.TrimSpace(strings.Join(args[1:], " "))
+		if text == "" {
+			fmt.Fprintln(os.Stderr, "add requires task text")
+			return 2
+		}
+		lock, lerr := storage.AcquireLock(jsonPath)
+		if lerr != nil {
+			fmt.Fprintln(os.Stderr, lerr)
+			return 1
+		}
+		defer lock.Release()
+
+		list, err := storage.LoadTasks(jsonPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		list = tasks.Add(list, text)
+		if err := storage.SaveTasks(jsonPath, list); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Fprintf(os.Stdout, "added #%d\n", list[len(list)-1].ID)
+		return 0
+
+	case "list":
+		fs := flag.NewFlagSet("list", flag.ContinueOnError)
+		reverse := fs.Bool("reverse", false, "reverse order (oldest-first)")
+		// prevent flag package from writing to stderr on parse error
+		fs.SetOutput(new(nopWriter))
+		if err := fs.Parse(args[1:]); err != nil {
+			fmt.Fprintln(os.Stderr, "invalid flags")
+			return 2
+		}
+		list, err := storage.LoadTasks(jsonPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if *reverse {
+			list = tasks.SortOldestFirst(list)
+		} else {
+			list = tasks.SortNewestFirst(list)
+		}
+		for _, t := range list {
+			state := " "
+			if t.Done {
+				state = "x"
+			}
+			fmt.Fprintf(os.Stdout, "[%s] #%d %s\n", state, t.ID, t.Text)
+		}
+		return 0
+
+	case "done":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "done requires an ID")
+			return 2
+		}
+		id, convErr := strconv.Atoi(args[1])
+		if convErr != nil {
+			fmt.Fprintln(os.Stderr, "invalid ID")
+			return 2
+		}
+		lock, lerr := storage.AcquireLock(jsonPath)
+		if lerr != nil {
+			fmt.Fprintln(os.Stderr, lerr)
+			return 1
+		}
+		defer lock.Release()
+
+		list, err := storage.LoadTasks(jsonPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		list, err = tasks.MarkDone(list, id)
+		if err != nil {
+			if errors.Is(err, tasks.ErrNotFound) {
+				fmt.Fprintln(os.Stderr, "no such task")
+				return 2
+			}
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if err := storage.SaveTasks(jsonPath, list); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Fprintf(os.Stdout, "done #%d\n", id)
+		return 0
+
+	case "rm":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "rm requires an ID")
+			return 2
+		}
+		id, convErr := strconv.Atoi(args[1])
+		if convErr != nil {
+			fmt.Fprintln(os.Stderr, "invalid ID")
+			return 2
+		}
+		lock, lerr := storage.AcquireLock(jsonPath)
+		if lerr != nil {
+			fmt.Fprintln(os.Stderr, lerr)
+			return 1
+		}
+		defer lock.Release()
+
+		list, err := storage.LoadTasks(jsonPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		list, err = tasks.Remove(list, id)
+		if err != nil {
+			if errors.Is(err, tasks.ErrNotFound) {
+				fmt.Fprintln(os.Stderr, "no such task")
+				return 2
+			}
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if err := storage.SaveTasks(jsonPath, list); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Fprintf(os.Stdout, "removed #%d\n", id)
+		return 0
+
+	case "clear":
+		lock, lerr := storage.AcquireLock(jsonPath)
+		if lerr != nil {
+			fmt.Fprintln(os.Stderr, lerr)
+			return 1
+		}
+		defer lock.Release()
+
+		// Clear regardless of existing content
+		if err := storage.SaveTasks(jsonPath, tasks.Clear(nil)); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Fprintln(os.Stdout, "cleared")
+		return 0
+
+	default:
+		fmt.Fprintln(os.Stderr, "unknown command")
+		return 2
+	}
+}
+
+type nopWriter struct{}
+
+func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func main() {
+	os.Exit(Run(os.Args[1:]))
+}

--- a/todo-cli/internal/storage/storage.go
+++ b/todo-cli/internal/storage/storage.go
@@ -1,11 +1,101 @@
 package storage
 
-import "github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
-func LoadTasks(path string) ([]tasks.Task, error) {
-	return nil, nil
+	"github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+)
+
+const (
+	envPath    = "TODO_CLI_PATH"
+	defaultRel = ".todo-cli/tasks.json"
+	lockName   = "tasks.lock"
+)
+
+type Lock struct {
+	path string
 }
 
-func SaveTasks(path string, taskList []tasks.Task) error {
-	return nil
+// DefaultPath returns the file path for tasks.json: $TODO_CLI_PATH or $HOME/.todo-cli/tasks.json.
+func DefaultPath() (string, error) {
+	if p := os.Getenv(envPath); p != "" {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, defaultRel), nil
+}
+
+// ensureDir ensures that the directory for the given file exists.
+func ensureDir(file string) error {
+	dir := filepath.Dir(file)
+	return os.MkdirAll(dir, 0o755)
+}
+
+// AcquireLock tries to create a lockfile next to the JSON file.
+// Best-effort: if it already exists, return an error.
+func AcquireLock(jsonPath string) (*Lock, error) {
+	dir := filepath.Dir(jsonPath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, err
+	}
+	lp := filepath.Join(dir, lockName)
+	f, err := os.OpenFile(lp, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("another process may be running (lock exists): %w", err)
+	}
+	// tiny bit of metadata (timestamp) to help debugging, ignore errors
+	_, _ = f.WriteString(time.Now().Format(time.RFC3339Nano))
+	_ = f.Close()
+	return &Lock{path: lp}, nil
+}
+
+// Release removes the lock file.
+func (l *Lock) Release() {
+	if l == nil || l.path == "" {
+		return
+	}
+	_ = os.Remove(l.path)
+}
+
+// LoadTasks loads tasks from jsonPath. If the file doesn't exist, returns empty list.
+func LoadTasks(jsonPath string) ([]tasks.Task, error) {
+	b, err := os.ReadFile(jsonPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, nil
+	}
+	var list []tasks.Task
+	if err := json.Unmarshal(b, &list); err != nil {
+		return nil, err
+	}
+	return list, nil
+}
+
+// SaveTasks writes tasks to jsonPath (pretty JSON).
+func SaveTasks(jsonPath string, list []tasks.Task) error {
+	if err := ensureDir(jsonPath); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(list, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := jsonPath + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, jsonPath)
 }

--- a/todo-cli/internal/tasks/tasks.go
+++ b/todo-cli/internal/tasks/tasks.go
@@ -1,27 +1,85 @@
 package tasks
 
-import "errors"
-
-var ErrTaskNotFound = errors.New("task not found")
+import (
+	"errors"
+	"sort"
+)
 
 type Task struct {
-	ID   int
-	Text string
-	Done bool
+	ID   int    `json:"id"`
+	Text string `json:"text"`
+	Done bool   `json:"done"`
+	// CreatedAt intentionally omitted from JSON schema for now to keep tests simple;
+	// newest-first is implemented via ID ordering.
 }
 
-func Add(taskList []Task, text string) []Task {
-	return nil
+var ErrNotFound = errors.New("task not found")
+
+// ErrTaskNotFound is kept for backward compatibility with earlier versions of
+// the package. It aliases ErrNotFound so older code (and tests) continue to
+// compile while newer code can use the shorter name.
+var ErrTaskNotFound = ErrNotFound
+
+// NextID returns the next sequential ID (max(existing)+1), starting at 1.
+func NextID(list []Task) int {
+	max := 0
+	for _, t := range list {
+		if t.ID > max {
+			max = t.ID
+		}
+	}
+	return max + 1
 }
 
-func MarkDone(taskList []Task, id int) ([]Task, error) {
-	return nil, ErrTaskNotFound
+// Add appends a new task with a new ID.
+func Add(list []Task, text string) []Task {
+	id := NextID(list)
+	return append(list, Task{ID: id, Text: text, Done: false})
 }
 
-func Remove(taskList []Task, id int) ([]Task, error) {
-	return nil, ErrTaskNotFound
+// MarkDone sets Done=true for the given id.
+func MarkDone(list []Task, id int) ([]Task, error) {
+	for i := range list {
+		if list[i].ID == id {
+			list[i].Done = true
+			return list, nil
+		}
+	}
+	return list, ErrNotFound
 }
 
-func Sort(taskList []Task, reverse bool) []Task {
-	return nil
+// Remove deletes the task with the given id.
+func Remove(list []Task, id int) ([]Task, error) {
+	for i := range list {
+		if list[i].ID == id {
+			return append(list[:i], list[i+1:]...), nil
+		}
+	}
+	return list, ErrNotFound
+}
+
+// Clear removes all tasks.
+func Clear(_ []Task) []Task { return nil }
+
+// SortNewestFirst returns a new slice sorted by ID desc (newest first).
+func SortNewestFirst(list []Task) []Task {
+	cp := append([]Task(nil), list...)
+	sort.Slice(cp, func(i, j int) bool { return cp[i].ID > cp[j].ID })
+	return cp
+}
+
+// SortOldestFirst returns a new slice sorted by ID asc.
+func SortOldestFirst(list []Task) []Task {
+	cp := append([]Task(nil), list...)
+	sort.Slice(cp, func(i, j int) bool { return cp[i].ID < cp[j].ID })
+	return cp
+}
+
+// Sort sorts tasks newest-first by default, or oldest-first when reverse is
+// true. It preserves the original slice by returning a copy.
+func Sort(list []Task, reverse bool) []Task {
+	if reverse {
+		return SortOldestFirst(list)
+	}
+	return SortNewestFirst(list)
 }


### PR DESCRIPTION
Implements the storage layer (JSON), task logic (ID assignment, done/rm/clear), and CLI command parsing (add, list, done <id>, rm <id>, clear). Default sort is newest-first (by ID, descending); `list --reverse` flips the order. Corrupted JSON returns an error. Includes a simple lockfile to discourage concurrent writes. Respects an env override for the state path to keep tests offline and hermetic.

**Closes #3.**

------
https://chatgpt.com/codex/tasks/task_b_68e67f0cdbec832f9f0bef8df7e3d579