### PR TITLE
feat(todo-cli): interactive menu (REPL) via stdlib

### DIFF
--- a/todo-cli/README.md
+++ b/todo-cli/README.md
@@ -4,6 +4,7 @@ Local TODO manager (CLI). Stores tasks in a JSON file on your machine.
 
 ## Features
 - Commands: `add`, `list`, `done <id>`, `rm <id>`, `clear`
+- Interactive menu: `todo-cli menu` or `TODO_CLI_MENU=1 todo-cli`
 - Default sort: newest first (by ID, descending); `list --reverse` flips order
 - JSON persistence at `~/.todo-cli/tasks.json` (overridable)
 - Standard library only; offline by default
@@ -60,6 +61,7 @@ todo-cli list [--reverse]       # List tasks (newest first; --reverse = oldest f
 todo-cli done <id>              # Mark the task with ID as done
 todo-cli rm <id>                # Remove the task with ID
 todo-cli clear                  # Remove all tasks
+todo-cli menu                   # Launch the interactive text menu
 Exit codes
 0 success
 

--- a/todo-cli/cmd/todo-cli/main.go
+++ b/todo-cli/cmd/todo-cli/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -77,8 +79,15 @@ func ParseCommand(args []string) (Command, error) {
 // Run is separated for testability. Returns exit code.
 func Run(args []string) int {
 	if len(args) == 0 {
+		if os.Getenv("TODO_CLI_MENU") == "1" {
+			return runMenu()
+		}
 		fmt.Fprintln(os.Stderr, "usage: todo-cli <add|list|done|rm|clear> [args]")
 		return 2
+	}
+
+	if args[0] == "menu" {
+		return runMenu()
 	}
 
 	// Resolve storage path
@@ -245,6 +254,158 @@ func Run(args []string) int {
 type nopWriter struct{}
 
 func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func runMenu() int {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Fprintln(os.Stdout, "")
+		fmt.Fprintln(os.Stdout, "TODO CLI MENU")
+		fmt.Fprintln(os.Stdout, "----------------")
+		fmt.Fprintln(os.Stdout, "1) Add task")
+		fmt.Fprintln(os.Stdout, "2) List tasks")
+		fmt.Fprintln(os.Stdout, "3) Mark done")
+		fmt.Fprintln(os.Stdout, "4) Remove task")
+		fmt.Fprintln(os.Stdout, "5) Clear tasks")
+		fmt.Fprintln(os.Stdout, "0) Exit")
+		fmt.Fprint(os.Stdout, "Select an option: ")
+
+		choice, err := readTrimmedLine(reader)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				fmt.Fprintln(os.Stdout)
+				return 0
+			}
+			fmt.Fprintln(os.Stderr, "input error:", err)
+			return 1
+		}
+
+		switch choice {
+		case "1":
+			text, err := promptLine(reader, "Enter task description: ")
+			if err != nil {
+				if errors.Is(err, io.EOF) {
+					fmt.Fprintln(os.Stdout)
+					return 0
+				}
+				fmt.Fprintln(os.Stderr, "input error:", err)
+				return 1
+			}
+			if text == "" {
+				fmt.Fprintln(os.Stdout, "no text entered")
+				continue
+			}
+			if exit := Run([]string{"add", text}); exit == 1 {
+				return 1
+			}
+		case "2":
+			if exit := menuList(); exit != -1 {
+				return exit
+			}
+		case "3":
+			id, ok, exitCode := promptID(reader, "mark done")
+			if exitCode >= 0 {
+				return exitCode
+			}
+			if !ok {
+				continue
+			}
+			if exit := Run([]string{"done", id}); exit == 1 {
+				return 1
+			}
+		case "4":
+			id, ok, exitCode := promptID(reader, "remove")
+			if exitCode >= 0 {
+				return exitCode
+			}
+			if !ok {
+				continue
+			}
+			if exit := Run([]string{"rm", id}); exit == 1 {
+				return 1
+			}
+		case "5":
+			if exit := Run([]string{"clear"}); exit == 1 {
+				return 1
+			}
+		case "0":
+			fmt.Fprintln(os.Stdout, "Goodbye!")
+			return 0
+		default:
+			if strings.EqualFold(choice, "exit") {
+				fmt.Fprintln(os.Stdout, "Goodbye!")
+				return 0
+			}
+			fmt.Fprintln(os.Stderr, "invalid selection")
+		}
+	}
+}
+
+func promptLine(reader *bufio.Reader, prompt string) (string, error) {
+	fmt.Fprint(os.Stdout, prompt)
+	return readTrimmedLine(reader)
+}
+
+func promptID(reader *bufio.Reader, action string) (string, bool, int) {
+	fmt.Fprintf(os.Stdout, "Enter task ID to %s: ", action)
+	line, err := readTrimmedLine(reader)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			fmt.Fprintln(os.Stdout)
+			return "", false, 0
+		}
+		fmt.Fprintln(os.Stderr, "input error:", err)
+		return "", false, 1
+	}
+	if line == "" {
+		fmt.Fprintln(os.Stdout, "no ID entered")
+		return "", false, -1
+	}
+	if _, convErr := strconv.Atoi(line); convErr != nil {
+		fmt.Fprintln(os.Stdout, "invalid ID")
+		return "", false, -1
+	}
+	return line, true, -1
+}
+
+func menuList() int {
+	jsonPath, err := storage.DefaultPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error resolving storage path:", err)
+		return 1
+	}
+	list, err := storage.LoadTasks(jsonPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	if len(list) == 0 {
+		fmt.Fprintln(os.Stdout, "No tasks found.")
+		return -1
+	}
+	list = tasks.SortNewestFirst(list)
+	for _, t := range list {
+		state := " "
+		if t.Done {
+			state = "x"
+		}
+		fmt.Fprintf(os.Stdout, "[%s] #%d %s\n", state, t.ID, t.Text)
+	}
+	return -1
+}
+
+func readTrimmedLine(reader *bufio.Reader) (string, error) {
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			if len(line) == 0 {
+				return "", io.EOF
+			}
+			return strings.TrimSpace(line), nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
 
 func main() {
 	os.Exit(Run(os.Args[1:]))

--- a/todo-cli/cmd/todo-cli/menu_test.go
+++ b/todo-cli/cmd/todo-cli/menu_test.go
@@ -140,7 +140,7 @@ func TestMenuScenarios(t *testing.T) {
 						t.Setenv(k, v)
 					}
 
-					stdout, stderr, exit := runMenu(t, ep.args, tc.script)
+					stdout, stderr, exit := runMenuHarness(t, ep.args, tc.script)
 					if exit != tc.wantExit {
 						t.Fatalf("expected exit %d, got %d. stdout=%q stderr=%q", tc.wantExit, exit, stdout, stderr)
 					}
@@ -160,7 +160,7 @@ func TestMenuScenarios(t *testing.T) {
 	}
 }
 
-func runMenu(t *testing.T, args []string, input string) (string, string, int) {
+func runMenuHarness(t *testing.T, args []string, input string) (string, string, int) {
 	t.Helper()
 
 	inR, inW, err := os.Pipe()


### PR DESCRIPTION
Adds an interactive text menu. Users can launch it with `todo-cli menu` or by setting `TODO_CLI_MENU=1` when no args are provided. The menu shows options (Add, List, Done, Remove, Clear, Exit), reads input from stdin, and calls existing logic. Backward compatible with non-interactive commands. Minimal README update to mention the menu. Stdlib only.

**Closes #123.**

------
https://chatgpt.com/codex/tasks/task_b_68ea8d930348832f8d6d0825b9a6a04f