### PR TITLE
test(todo-cli): introduce MenuUI interface and add selection tests

### DIFF
--- a/todo-cli/cmd/todo-cli/main.go
+++ b/todo-cli/cmd/todo-cli/main.go
@@ -12,9 +12,12 @@ import (
 
 	"github.com/pekomon/go-sandbox/todo-cli/internal/storage"
 	"github.com/pekomon/go-sandbox/todo-cli/internal/tasks"
+	"github.com/pekomon/go-sandbox/todo-cli/internal/ui"
 )
 
 var ErrUnknownCommand = errors.New("unknown command")
+
+var menuUI ui.MenuUI
 
 type Command struct {
 	Name string
@@ -256,6 +259,10 @@ type nopWriter struct{}
 func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }
 
 func runMenu() int {
+	if menuUI == nil {
+		fmt.Fprintln(os.Stderr, "interactive menu not available")
+		return 1
+	}
 	reader := bufio.NewReader(os.Stdin)
 	for {
 		fmt.Fprintln(os.Stdout, "")

--- a/todo-cli/cmd/todo-cli/menu_ui_test.go
+++ b/todo-cli/cmd/todo-cli/menu_ui_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/todo-cli/internal/ui"
+)
+
+const (
+	menuIndexList = iota
+	menuIndexAdd
+	menuIndexDone
+	menuIndexRemove
+	menuIndexClear
+	menuIndexExit
+)
+
+func TestMenuSelectionsViaUI(t *testing.T) {
+	t.Setenv("TODO_CLI_PATH", filepath.Join(t.TempDir(), "tasks.json"))
+
+	fake := &ui.Fake{
+		Choices: []int{
+			menuIndexList,
+			menuIndexAdd,
+			menuIndexDone,
+			menuIndexRemove,
+			menuIndexClear,
+			menuIndexExit,
+		},
+	}
+
+	stdout, stderr, exit := runMenuWithFakeUI(t, fake)
+
+	if exit != 0 {
+		t.Fatalf("expected exit code 0, got %d. stdout=%q stderr=%q", exit, stdout, stderr)
+	}
+
+	wantStdout := []string{
+		"No tasks found.",
+		"added #1",
+		"done #1",
+		"removed #1",
+		"cleared",
+		"Goodbye!",
+	}
+
+	for _, want := range wantStdout {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("expected stdout to contain %q, got:\n%s", want, stdout)
+		}
+	}
+
+	if stderr != "" {
+		t.Fatalf("unexpected stderr output:\n%s", stderr)
+	}
+}
+
+func runMenuWithFakeUI(t *testing.T, fake ui.MenuUI) (string, string, int) {
+	t.Helper()
+
+	previous := menuUI
+	menuUI = fake
+	defer func() {
+		menuUI = previous
+	}()
+
+	return runMenuHarness(t, []string{"menu"}, "")
+}

--- a/todo-cli/internal/ui/ui.go
+++ b/todo-cli/internal/ui/ui.go
@@ -1,0 +1,23 @@
+package ui
+
+type MenuUI interface {
+	Select(title string, options []string) (index int, err error)
+}
+
+type Fake struct {
+	Choices []int
+	Err     error
+	i       int
+}
+
+func (f *Fake) Select(_ string, _ []string) (int, error) {
+	if f.Err != nil {
+		return 0, f.Err
+	}
+	if f.i >= len(f.Choices) {
+		return 0, nil
+	}
+	v := f.Choices[f.i]
+	f.i++
+	return v, nil
+}


### PR DESCRIPTION
Introduces a small `MenuUI` interface to abstract interactive selection and adds unit tests using a fake implementation. No external dependencies yet. The tests will fail until the CLI is wired to use `MenuUI` in menu mode.

**Closes #24**

------
https://chatgpt.com/codex/tasks/task_b_68eab9b4f750832faa3810facd61e35b