### PR TITLE
Improve todo-cli README usage guidance

### DIFF
--- a/todo-cli/README.md
+++ b/todo-cli/README.md
@@ -1,17 +1,78 @@
 # todo-cli
 
-Local TODO manager (CLI). Stores tasks in a JSON file on your machine.
+Local todo manager for the terminal. Tasks live in a JSON file on your machine, and the app works fully offline.
 
 ## Features
-- Commands: `add`, `list`, `done <id>`, `rm <id>`, `clear`
-- Interactive menu: `todo-cli menu` or `TODO_CLI_MENU=1 todo-cli`
-- Default sort: newest first (by ID, descending); `list --reverse` flips order
-- JSON persistence at `~/.todo-cli/tasks.json` (overridable)
-- Standard library only; offline by default
+- Straightforward commands: `add`, `list`, `done <id>`, `rm <id>`, `clear`, `menu`
+- Interactive menu with arrow-key navigation (surveys) and a text-mode fallback
+- Tasks stored at `~/.todo-cli/tasks.json` (configurable via env var)
+- Default ordering shows the newest entries first; `--reverse` lists oldest first
+- Standard-library dependencies only
 
-## Interactive menu (arrow keys)
+## Installation
 
-When run in an interactive terminal, the menu uses arrow keys via [survey.Select](https://github.com/AlecAivazis/survey) to choose an action:
+Build from source (module is in this directory).
+
+```bash
+# From the repo root
+cd todo-cli
+make build
+# Binary is written to ./bin/todo-cli
+```
+
+Or build directly with Go:
+
+```bash
+cd todo-cli
+go build -o bin/todo-cli ./cmd/todo-cli
+```
+
+## Usage
+
+### Quick start
+
+```bash
+# Add tasks
+./bin/todo-cli add "Read Go docs"
+./bin/todo-cli add "Write unit tests"
+
+# List tasks (newest first by default)
+./bin/todo-cli list
+
+# Mark a task complete
+./bin/todo-cli done 1
+
+# Remove a task
+./bin/todo-cli rm 2
+
+# Clear all tasks
+./bin/todo-cli clear
+```
+
+### Command reference
+
+```text
+todo-cli add <text...>        Add a new task with the provided text
+todo-cli list [--reverse]     List tasks (newest first; --reverse flips to oldest first)
+todo-cli done <id>            Mark the task with ID as done
+todo-cli rm <id>              Remove the task with ID
+todo-cli clear                Remove all tasks
+todo-cli menu                 Launch the interactive menu UI
+```
+
+### Exit codes
+
+| Code | Meaning                                                                 |
+|------|-------------------------------------------------------------------------|
+| 0    | Success                                                                 |
+| 1    | Runtime/storage error (I/O failure, corrupted JSON, lock acquisition)   |
+| 2    | Usage error (unknown command, missing/invalid arguments)                |
+
+Errors are written to stderr; normal output uses stdout.
+
+## Interactive menu
+
+Launch it with `todo-cli menu`, or run `TODO_CLI_MENU=1 todo-cli` to enter the menu automatically when no arguments are provided. When the app detects an interactive terminal it uses arrow keys (via [survey.Select](https://github.com/AlecAivazis/survey)) and `Enter` to pick an action:
 
 ```
 TODO CLI MENU
@@ -23,140 +84,82 @@ TODO CLI MENU
   Exit
 ```
 
-Non-interactive shells fall back to the numbered text prompts.
+- Press `Enter` to confirm a highlighted item.
+- Choose **Exit** or press `Ctrl+C` to quit; either path returns exit code 0.
+- If the process cannot use the survey UI (for example in a non-TTY shell), it falls back to a numbered text menu:
+  ```
+  TODO CLI MENU
+  ----------------
+  1) Add task
+  2) List tasks
+  3) Mark done
+  4) Remove task
+  5) Clear tasks
+  0) Exit
+  ```
+  Type the number (or `exit`) and press `Enter` to proceed.
 
-## Installation
+IDs requested by menu prompts must be numeric; blank or invalid input keeps the menu open without running a command.
 
-Build from source (module lives in this subfolder):
+## Configuration
+
+- `TODO_CLI_PATH` overrides the default JSON location.
+  ```bash
+  export TODO_CLI_PATH="$(mktemp -d)/tasks.json"
+  ./bin/todo-cli add "Temporary task"
+  ./bin/todo-cli list
+  ```
+- `TODO_CLI_MENU=1` makes `todo-cli` (with no arguments) launch directly into the menu.
+
+### Persistence & locking
+
+- Default data path: `~/.todo-cli/tasks.json`
+- Lock file: `~/.todo-cli/tasks.lock`
+- The CLI writes a temporary `.tmp` file and renames it for atomic saves.
+- Locking uses a simple `O_CREATE|O_EXCL` file. If another process holds the lock, commands exit with code 1 and report `another process may be running (lock exists)`.
+- After an unexpected crash you may need to remove a stale lock manually:
+  ```bash
+  rm -f ~/.todo-cli/tasks.lock
+  ```
+
+## Testing
 
 ```bash
-# From repo root
-cd todo-cli
-make build
-# Binary at: ./bin/todo-cli
-Or with plain go:
-
-bash
-Copy code
-cd todo-cli
-go build -o bin/todo-cli ./cmd/todo-cli
-Quick Start
-bash
-Copy code
-# Add a couple of tasks
-./bin/todo-cli add "Read Go docs"
-./bin/todo-cli add "Write unit tests"
-
-# List tasks (newest first)
-./bin/todo-cli list
-# Example output:
-# [ ] #2 Write unit tests
-# [ ] #1 Read Go docs
-
-# Mark a task done
-./bin/todo-cli done 1
-# stdout: done #1
-
-# List again
-./bin/todo-cli list
-# [ ] #2 Write unit tests
-# [x] #1 Read Go docs
-
-# Remove a task
-./bin/todo-cli rm 2
-# stdout: removed #2
-
-# Clear all tasks
-./bin/todo-cli clear
-# stdout: cleared
-Command Reference
-bash
-Copy code
-todo-cli add <text...>          # Add a new task with the given text
-todo-cli list [--reverse]       # List tasks (newest first; --reverse = oldest first)
-todo-cli done <id>              # Mark the task with ID as done
-todo-cli rm <id>                # Remove the task with ID
-todo-cli clear                  # Remove all tasks
-todo-cli menu                   # Launch the interactive text menu
-Exit codes
-0 success
-
-1 runtime/storage error (e.g., I/O, corrupted JSON, lock acquisition fails)
-
-2 usage error (unknown command, missing/invalid arguments)
-
-Errors are printed to stderr; normal output to stdout.
-
-Persistence
-By default, tasks are stored at:
-
-Path: ~/.todo-cli/tasks.json
-
-You can override the location for local runs or tests:
-
-Environment variable: TODO_CLI_PATH=/path/to/tasks.json
-
-Example:
-
-bash
-Copy code
-export TODO_CLI_PATH="$(mktemp -d)/tasks.json"
-./bin/todo-cli add "Temporary task"
-./bin/todo-cli list
-Locking & concurrency
-To reduce the chance of concurrent writes, the CLI uses a best-effort lock file next to tasks.json:
-
-Lock file: tasks.lock
-
-Behavior: creates the file with O_CREATE|O_EXCL; if it exists, the command fails
-
-Limitation: on crash/kill, a stale lock may remain; remove it manually if needed
-
-This is intentionally simple. If stronger guarantees are required later, we can upgrade the locking strategy in a future PR.
-
-Testing
-Run tests for this subproject:
-
-bash
-Copy code
 cd todo-cli
 make test
+```
+
 Generate coverage locally:
 
-bash
-Copy code
+```bash
 cd todo-cli
 make cover
-# Outputs cover.out and a summary
-CI runs go test ./... -coverprofile=cover.out on every PR/push and uploads artifacts.
+# Produces cover.out and a summary
+```
 
-Development Notes
-IDs are sequential starting at 1 (new tasks get max(id)+1)
+CI runs `go test ./... -coverprofile=cover.out` on every PR/push and stores artifacts.
 
-“Newest first” is implemented via ID ordering to keep the data model small
+## Development notes
 
-JSON schema (minimal):
+- IDs are sequential starting at 1; new tasks get `max(id) + 1`.
+- Newest-first listing is implemented via ID ordering to avoid storing timestamps.
+- Minimal JSON structure:
+  ```json
+  [
+    { "id": 1, "text": "example task", "done": false }
+  ]
+  ```
 
-json
-Copy code
-[
-  { "id": 1, "text": "example", "done": false }
-]
-Troubleshooting
-"another process may be running (lock exists)"
-A previous run created tasks.lock. If you are sure no other instance runs, remove the lock file:
+## Troubleshooting
 
-bash
-Copy code
-rm -f ~/.todo-cli/tasks.lock
-Or point to a different JSON path using TODO_CLI_PATH.
+- **"another process may be running (lock exists)"**  
+  Ensure no other `todo-cli` instance is mutating the same file. Remove the lock with `rm -f ~/.todo-cli/tasks.lock`, or point `TODO_CLI_PATH` at a different file.
 
-"invalid ID" / "no such task"
-Use todo-cli list to inspect current IDs.
+- **"invalid ID" or "no such task"**  
+  Run `todo-cli list` to check the current task IDs, then retry.
 
-Corrupted JSON
-The CLI returns an error instead of silently resetting. Fix or move the file, or start with a fresh path:
-
-bash
-Copy code
-mv ~/.todo-cli/tasks.json ~/.todo-cli/tasks.json.bak.$(date +%s)
+- **Corrupted JSON**  
+  The CLI refuses to overwrite invalid data. Fix the file manually or back it up and start fresh:
+  ```bash
+  mv ~/.todo-cli/tasks.json ~/.todo-cli/tasks.json.bak.$(date +%s)
+  ```


### PR DESCRIPTION
## Summary
- restructure todo-cli README to fix formatting and clarify usage
- document interactive menu behaviour, configuration env vars, and troubleshooting guidance

## Testing
- not run (docs only)

Closes #32
