### PR TITLE
test(guessr): add failing tests (stdin simulation, seeded RNG, stats)

### DIFF
--- a/guessr/cmd/guessr/main.go
+++ b/guessr/cmd/guessr/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	// Intentionally empty for tests-first; CLI will be implemented in a later PR.
+}

--- a/guessr/internal/game/game.go
+++ b/guessr/internal/game/game.go
@@ -1,0 +1,38 @@
+package game
+
+import (
+	"io"
+)
+
+type Options struct {
+	Max      int // default: 100
+	Attempts int // default: 7
+	Seed     int64
+}
+
+var ErrNotImplemented = errNotImplemented("not implemented")
+
+type errNotImplemented string
+
+func (e errNotImplemented) Error() string { return string(e) }
+
+// Run plays one game by reading guesses (one per line) from r and writing hints/results to w.
+// It should respect Options and use the provided random seed (deterministic).
+// STUB for now: return ErrNotImplemented so tests fail.
+func Run(r io.Reader, w io.Writer, opts Options, stats StatsStore) error {
+	return ErrNotImplemented
+}
+
+// StatsStore abstracts persistence (implemented in internal/stats).
+type StatsStore interface {
+	Load() (Stats, error)
+	Save(Stats) error
+}
+
+// Stats describes game statistics.
+type Stats struct {
+	Games          int     `json:"games"`
+	Wins           int     `json:"wins"`
+	TotalGuesses   int     `json:"total_guesses"`
+	AverageGuesses float64 `json:"average_guesses"`
+}

--- a/guessr/internal/game/game_test.go
+++ b/guessr/internal/game/game_test.go
@@ -1,0 +1,175 @@
+package game_test
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/guessr/internal/game"
+)
+
+type fakeStats struct {
+	load    game.Stats
+	saved   game.Stats
+	saveErr error
+}
+
+func (f *fakeStats) Load() (game.Stats, error) { return f.load, nil }
+func (f *fakeStats) Save(s game.Stats) error {
+	f.saved = s
+	return f.saveErr
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		opts         game.Options
+		prepare      func(target, max int, opts game.Options) []int
+		wantSubstr   []string
+		wantStats    game.Stats
+		wantErr      bool
+		errContains  string
+		prependInput []string
+	}{
+		{
+			name: "win within attempts",
+			opts: game.Options{Max: 10, Attempts: 5, Seed: 42},
+			prepare: func(target, max int, opts game.Options) []int {
+				return hintGuesses(target, max)
+			},
+			wantSubstr: []string{"higher", "lower", "correct"},
+			wantStats:  game.Stats{Games: 1, Wins: 1, TotalGuesses: 3, AverageGuesses: 3},
+		},
+		{
+			name: "out of attempts",
+			opts: game.Options{Max: 10, Attempts: 3, Seed: 99},
+			prepare: func(target, max int, opts game.Options) []int {
+				return losingGuesses(target, max, opts.Attempts)
+			},
+			wantSubstr: []string{"game over"},
+			wantStats:  game.Stats{Games: 1, Wins: 0, TotalGuesses: 3, AverageGuesses: 3},
+		},
+		{
+			name:         "invalid input",
+			opts:         game.Options{Seed: 7},
+			wantErr:      true,
+			errContains:  "invalid",
+			prependInput: []string{"oops"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := tt.opts
+			max := opts.Max
+			if max == 0 {
+				max = 100
+			}
+			if opts.Attempts == 0 {
+				opts.Attempts = 7
+			}
+
+			guesses := make([]int, 0)
+			if tt.prepare != nil {
+				target := expectedTarget(opts.Seed, max)
+				guesses = append(guesses, tt.prepare(target, max, opts)...)
+			}
+
+			inputs := make([]string, 0, len(tt.prependInput)+len(guesses))
+			inputs = append(inputs, tt.prependInput...)
+			for _, g := range guesses {
+				inputs = append(inputs, fmt.Sprintf("%d", g))
+			}
+
+			out, fs, err := runGame(t, opts, strings.Join(inputs, "\n")+"\n")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Run() error = nil, want non-nil")
+				}
+				if tt.errContains != "" && !strings.Contains(strings.ToLower(err.Error()), strings.ToLower(tt.errContains)) {
+					t.Fatalf("Run() error = %q, want contains %q", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Run() error = %v, want nil", err)
+			}
+
+			lowerOut := strings.ToLower(out)
+			for _, substr := range tt.wantSubstr {
+				if !strings.Contains(lowerOut, substr) {
+					t.Errorf("output %q does not contain %q", out, substr)
+				}
+			}
+
+			if tt.wantStats != (game.Stats{}) {
+				if fs.saved != tt.wantStats {
+					t.Errorf("saved stats = %+v, want %+v", fs.saved, tt.wantStats)
+				}
+			}
+		})
+	}
+}
+
+func runGame(t *testing.T, opts game.Options, input string) (string, *fakeStats, error) {
+	t.Helper()
+
+	in := bytes.NewBufferString(input)
+	out := &bytes.Buffer{}
+	stats := &fakeStats{}
+
+	err := game.Run(in, out, opts, stats)
+	return out.String(), stats, err
+}
+
+func expectedTarget(seed int64, max int) int {
+	if seed == 0 {
+		seed = 1
+	}
+	r := rand.New(rand.NewSource(seed))
+	return r.Intn(max) + 1
+}
+
+func hintGuesses(target, max int) []int {
+	guesses := make([]int, 0, 3)
+	if target > 1 {
+		guesses = append(guesses, target-1)
+	} else {
+		guesses = append(guesses, target+1)
+	}
+	if target < max {
+		guesses = append(guesses, target+1)
+	} else {
+		guesses = append(guesses, target-1)
+	}
+	guesses = append(guesses, target)
+	return guesses
+}
+
+func losingGuesses(target, max, attempts int) []int {
+	guesses := make([]int, 0, attempts)
+	current := 1
+	for len(guesses) < attempts {
+		if current == target {
+			current++
+			if current > max {
+				current = 1
+			}
+			continue
+		}
+		guesses = append(guesses, current)
+		current++
+		if current > max {
+			current = 1
+		}
+	}
+	return guesses
+}

--- a/guessr/internal/stats/stats.go
+++ b/guessr/internal/stats/stats.go
@@ -1,0 +1,19 @@
+package stats
+
+import "github.com/pekomon/go-sandbox/guessr/internal/game"
+
+// Path resolution is env-overridable for tests:
+//
+//	GUESSR_STATS_PATH=/tmp/whatever.json
+const EnvPath = "GUESSR_STATS_PATH"
+
+// Store is a file-backed implementation of game.StatsStore.
+// STUB for now: methods return ErrNotImplemented.
+type Store struct {
+	// jsonPath string
+}
+
+func NewStore() (*Store, error) { return &Store{}, nil }
+
+func (s *Store) Load() (game.Stats, error) { return game.Stats{}, game.ErrNotImplemented }
+func (s *Store) Save(st game.Stats) error  { return game.ErrNotImplemented }

--- a/guessr/internal/stats/stats_test.go
+++ b/guessr/internal/stats/stats_test.go
@@ -1,0 +1,92 @@
+package stats_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/guessr/internal/game"
+	"github.com/pekomon/go-sandbox/guessr/internal/stats"
+)
+
+func TestStoreLoadMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(stats.EnvPath, filepath.Join(dir, "stats.json"))
+
+	store, err := stats.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	got, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got != (game.Stats{}) {
+		t.Fatalf("Load() = %+v, want zero stats", got)
+	}
+}
+
+func TestStoreSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	statsPath := filepath.Join(dir, "stats.json")
+	t.Setenv(stats.EnvPath, statsPath)
+
+	store, err := stats.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	want := game.Stats{Games: 3, Wins: 2, TotalGuesses: 9, AverageGuesses: 3}
+	if err := store.Save(want); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	got, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if got != want {
+		t.Fatalf("round-trip stats = %+v, want %+v", got, want)
+	}
+}
+
+func TestStoreLoadCorruptedJSON(t *testing.T) {
+	dir := t.TempDir()
+	statsPath := filepath.Join(dir, "stats.json")
+	t.Setenv(stats.EnvPath, statsPath)
+
+	raw := []byte("not-json")
+	if err := os.WriteFile(statsPath, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	store, err := stats.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore() error = %v", err)
+	}
+
+	if _, err := store.Load(); err == nil {
+		t.Fatalf("Load() error = nil, want error")
+	}
+}
+
+func TestStatsJSONTags(t *testing.T) {
+	statsJSON := game.Stats{Games: 1, Wins: 1, TotalGuesses: 5, AverageGuesses: 5.0}
+	data, err := json.Marshal(statsJSON)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var roundTrip game.Stats
+	if err := json.Unmarshal(data, &roundTrip); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if roundTrip != statsJSON {
+		t.Fatalf("roundTrip stats = %+v, want %+v", roundTrip, statsJSON)
+	}
+}


### PR DESCRIPTION
Adds table-driven tests for the `guessr` game covering deterministic seeding, stdin simulation, attempts limit, and JSON stats persistence. Includes minimal stubs so the package compiles; tests are expected to fail until the implementation lands.

**Closes #6.**

------
https://chatgpt.com/codex/tasks/task_b_68f49bc35a90832fb4e4c8d3fb0a67f3