### PR TITLE
ci: run workflows on Go 1.24.x and 1.25.x

### DIFF
--- a/.github/workflows/guessr.yml
+++ b/.github/workflows/guessr.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ "1.24.x", "1.25.x" ]
     defaults:
       run:
         working-directory: guessr
@@ -26,10 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
+      - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: ${{ matrix.go-version }}
 
       - name: Go env
         run: go env
@@ -37,18 +41,18 @@ jobs:
       - name: Run tests with coverage
         run: |
           set -e
-          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../guessr-test-output.txt
+          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../guessr-test-output-${{ matrix.go-version }}.txt
 
-      - name: Upload coverage
+      - name: Upload coverage (${{ matrix.go-version }})
         uses: actions/upload-artifact@v4
         with:
-          name: guessr-coverage
+          name: guessr-coverage-${{ matrix.go-version }}
           path: guessr/cover.out
           if-no-files-found: warn
 
-      - name: Upload test output
+      - name: Upload test output (${{ matrix.go-version }})
         uses: actions/upload-artifact@v4
         with:
-          name: guessr-test-output
-          path: guessr-test-output.txt
+          name: guessr-test-output-${{ matrix.go-version }}
+          path: guessr-test-output-${{ matrix.go-version }}.txt
           if-no-files-found: warn

--- a/.github/workflows/todo-cli.yml
+++ b/.github/workflows/todo-cli.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [ "1.24.x", "1.25.x" ]
     defaults:
       run:
         working-directory: todo-cli
@@ -26,10 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go
+      - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: ${{ matrix.go-version }}
 
       - name: Go env
         run: go env
@@ -37,18 +41,18 @@ jobs:
       - name: Run tests with coverage
         run: |
           set -e
-          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../todo-cli-test-output.txt
+          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../todo-cli-test-output-${{ matrix.go-version }}.txt
 
-      - name: Upload coverage
+      - name: Upload coverage (${{ matrix.go-version }})
         uses: actions/upload-artifact@v4
         with:
-          name: todo-cli-coverage
+          name: todo-cli-coverage-${{ matrix.go-version }}
           path: todo-cli/cover.out
           if-no-files-found: warn
 
-      - name: Upload test output
+      - name: Upload test output (${{ matrix.go-version }})
         uses: actions/upload-artifact@v4
         with:
-          name: todo-cli-test-output
-          path: todo-cli-test-output.txt
+          name: todo-cli-test-output-${{ matrix.go-version }}
+          path: todo-cli-test-output-${{ matrix.go-version }}.txt
           if-no-files-found: warn


### PR DESCRIPTION
Updates per-subproject workflows to run tests on both Go 1.24.x and 1.25.x. This helps validate the upcoming baseline upgrade without changing module toolchains yet. No code or go.mod changes in this PR.

**Closes #15.**

------
https://chatgpt.com/codex/tasks/task_b_68fbd6420160832f8380223725731424