### PR TITLE
chore: upgrade baseline to Go 1.25

### DIFF
--- a/.github/workflows/guessr.yml
+++ b/.github/workflows/guessr.yml
@@ -19,10 +19,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [ "1.24.x", "1.25.x" ]
     defaults:
       run:
         working-directory: guessr
@@ -30,10 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go 1.25.x
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.25.x"
 
       - name: Go env
         run: go env
@@ -41,18 +37,18 @@ jobs:
       - name: Run tests with coverage
         run: |
           set -e
-          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../guessr-test-output-${{ matrix.go-version }}.txt
+          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../guessr-test-output.txt
 
-      - name: Upload coverage (${{ matrix.go-version }})
+      - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: guessr-coverage-${{ matrix.go-version }}
+          name: guessr-coverage
           path: guessr/cover.out
           if-no-files-found: warn
 
-      - name: Upload test output (${{ matrix.go-version }})
+      - name: Upload test output
         uses: actions/upload-artifact@v4
         with:
-          name: guessr-test-output-${{ matrix.go-version }}
-          path: guessr-test-output-${{ matrix.go-version }}.txt
+          name: guessr-test-output
+          path: guessr-test-output.txt
           if-no-files-found: warn

--- a/.github/workflows/todo-cli.yml
+++ b/.github/workflows/todo-cli.yml
@@ -19,10 +19,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [ "1.24.x", "1.25.x" ]
     defaults:
       run:
         working-directory: todo-cli
@@ -30,10 +26,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Go ${{ matrix.go-version }}
+      - name: Setup Go 1.25.x
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.25.x"
 
       - name: Go env
         run: go env
@@ -41,18 +37,18 @@ jobs:
       - name: Run tests with coverage
         run: |
           set -e
-          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../todo-cli-test-output-${{ matrix.go-version }}.txt
+          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../todo-cli-test-output.txt
 
-      - name: Upload coverage (${{ matrix.go-version }})
+      - name: Upload coverage
         uses: actions/upload-artifact@v4
         with:
-          name: todo-cli-coverage-${{ matrix.go-version }}
+          name: todo-cli-coverage
           path: todo-cli/cover.out
           if-no-files-found: warn
 
-      - name: Upload test output (${{ matrix.go-version }})
+      - name: Upload test output
         uses: actions/upload-artifact@v4
         with:
-          name: todo-cli-test-output-${{ matrix.go-version }}
-          path: todo-cli-test-output-${{ matrix.go-version }}.txt
+          name: todo-cli-test-output
+          path: todo-cli-test-output.txt
           if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go-sandbox
 
-Multi-project Go repository (Go baseline: 1.24.3). Each subproject lives in its own module for clean boundaries, reproducible builds, and focused CI.
+Multi-project Go repository (Go baseline: 1.25). Each subproject lives in its own module for clean boundaries, reproducible builds, and focused CI.
 
 ## Subprojects
 - **todo-cli** — Local TODO manager CLI with JSON persistence (to be implemented in upcoming PRs).

--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,6 @@
 # Agents guide
 
-Audience: code-generation agents and contributors (Codex, Copilot, ChatGPT Coder).  
+Audience: code-generation agents and contributors (Codex, Copilot, ChatGPT Coder).
 Language: English only for code, comments, READMEs, commit messages.
 
 ## Repository shape
@@ -9,9 +9,11 @@ Language: English only for code, comments, READMEs, commit messages.
 - Root contains a minimal Makefile and top-level docs.
 
 ## Go & toolchain
-- Baseline: **Go 1.24** with `toolchain go1.24.3` in each module.
-- CI uses `actions/setup-go@v5` with `go-version: "1.24.x"`.
-- Future upgrade to 1.25 is tracked separately (do not change versions unless the PR is explicitly about toolchain).
+Baseline: Go 1.25.
+
+CI uses actions/setup-go@v5 with go-version: "1.25.x".
+
+Prefer not to use toolchain directives in modules to avoid redundant downloads in CI.
 
 ## Workflow rules
 - **One logical unit per PR**. Keep PRs focused and small.
@@ -46,7 +48,7 @@ Language: English only for code, comments, READMEs, commit messages.
 
 ## Subproject template (each module should have)
 - `README.md` — install, usage, tests/coverage, env vars, exit codes
-- `go.mod` — `go 1.24`, `toolchain go1.24.3`
+- `go.mod` — `go 1.25`
 - `Makefile` — targets: `deps` (tidy), `build` (only main pkg), `test`, `cover`, `clean`
 - `.gitignore` — standard Go ignores
 - `cmd/<binary>/` — CLI entrypoint (`package main`)
@@ -55,7 +57,7 @@ Language: English only for code, comments, READMEs, commit messages.
 ## CI
 - **One workflow per subproject** under `.github/workflows/<name>.yml`.
 - Use `on.push.paths` / `on.pull_request.paths` filters so only the touched subproject runs.
-- Steps: checkout, setup-go (1.24.x), `go test ./... -coverprofile=cover.out`, upload artifacts.
+- Steps: checkout, setup-go (1.25.x), `go test ./... -coverprofile=cover.out`, upload artifacts.
 
 ## Adding a new subproject (checklist)
 1) Create folder with module files: `README.md`, `.gitignore`, `Makefile`, `go.mod`, `internal/.gitkeep`, `cmd/<name>/.gitkeep`.

--- a/guessr/go.mod
+++ b/guessr/go.mod
@@ -1,5 +1,3 @@
 module github.com/pekomon/go-sandbox/guessr
 
-go 1.24
-
-toolchain go1.24.3
+go 1.25

--- a/todo-cli/go.mod
+++ b/todo-cli/go.mod
@@ -1,7 +1,5 @@
 module github.com/pekomon/go-sandbox/todo-cli
 
-go 1.24
-
-toolchain go1.24.3
+go 1.25
 
 require github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Raises the baseline to Go 1.25 across modules and CI. Removes module-level `toolchain` directives to avoid duplicate downloads in CI; `actions/setup-go@v5` installs 1.25.x. No source code changes.

**Closes #14.**

------
https://chatgpt.com/codex/tasks/task_b_68fc74788864832f9d11521ba08a2e91