### PR TITLE
feat(filesort): implement extension-based sorter and CLI with --dry-run

### DIFF
--- a/filesort/cmd/filesort/main.go
+++ b/filesort/cmd/filesort/main.go
@@ -1,9 +1,56 @@
 package main
 
-import "os"
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/pekomon/go-sandbox/filesort/internal/sorter"
+)
 
 func main() {
-	// Intentionally empty for tests-first; CLI wiring will be added in a later PR.
-	// The tests exercise internal/sorter directly for now.
-	os.Exit(0)
+	os.Exit(run(os.Args[1:]))
 }
+
+func run(args []string) int {
+	var dryRun bool
+	fs := flag.NewFlagSet("filesort", flag.ContinueOnError)
+	fs.BoolVar(&dryRun, "dry-run", false, "plan only; do not modify the filesystem")
+	// silence default usage on parse error
+	fs.SetOutput(new(nopWriter))
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprintln(os.Stderr, "invalid flags")
+		return 2
+	}
+	rest := fs.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(os.Stderr, "usage: filesort [--dry-run] <rootDir>")
+		return 2
+	}
+	root := rest[0]
+
+	plan, err := sorter.BuildPlan(root, dryRun)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
+	if dryRun {
+		// Print a small summary; helpful for future assertions and user feedback.
+		fmt.Fprintf(os.Stdout, "dry-run: %d moves planned\n", len(plan.Moves))
+		for src, dst := range plan.Moves {
+			fmt.Fprintf(os.Stdout, "%s -> %s\n", src, dst)
+		}
+		return 0
+	}
+
+	if err := sorter.Apply(plan); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+	return 0
+}
+
+type nopWriter struct{}
+
+func (*nopWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/filesort/cmd/filesort/main_test.go
+++ b/filesort/cmd/filesort/main_test.go
@@ -10,10 +10,6 @@ import (
 	"testing"
 )
 
-// We keep this test light: it invokes "go run ./cmd/filesort" to ensure "--dry-run" is recognized
-// in the future implementation. For now we expect the command to exist; behavior assertions are
-// commented out until the feature PR wires flags.
-
 func TestCLI_DryRunFlag_WiresThrough(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short")
@@ -23,22 +19,20 @@ func TestCLI_DryRunFlag_WiresThrough(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	// Create a couple of files that would be classified later
 	_ = os.WriteFile(filepath.Join(root, "a.jpg"), []byte("x"), 0o644)
 	_ = os.WriteFile(filepath.Join(root, "b.txt"), []byte("x"), 0o644)
 
+	// Run from module root so `go run ./cmd/filesort` resolves correctly.
 	cmd := exec.Command("go", "run", "./cmd/filesort", "--dry-run", root)
 	cmd.Dir = filepath.Join("..") // from filesort/cmd/filesort to filesort/
 	var out, errb bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errb
 	err := cmd.Run()
-
-	// Until CLI wiring exists, we accept non-zero exit and/or stderr output.
-	if err == nil && strings.TrimSpace(errb.String()) == "" {
-		// Uncomment in the implementation PR to assert stable messages:
-		// if !strings.Contains(out.String(), "dry-run") {
-		// t.Fatalf("expected mention of dry-run in output")
-		// }
+	if err != nil {
+		t.Fatalf("go run: %v, stderr: %s", err, errb.String())
+	}
+	if !strings.Contains(out.String(), "dry-run") {
+		t.Fatalf("expected 'dry-run' mention in output; got: %s", out.String())
 	}
 }

--- a/filesort/internal/sorter/sorter.go
+++ b/filesort/internal/sorter/sorter.go
@@ -1,27 +1,104 @@
 package sorter
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 var ErrNotImplemented = errors.New("not implemented")
 
-// Class represents a logical destination folder, e.g. "images", "docs", "videos", "other".
+// Class represents a logical destination folder.
 type Class string
 
-// Plan is a set of moves from absolute source to absolute destination (both must be under the root dir).
+const (
+	ClassImages Class = "images"
+	ClassDocs   Class = "docs"
+	ClassVideos Class = "videos"
+	ClassOther  Class = "other"
+)
+
+// Plan is a set of moves from absolute source to absolute destination (both under Root).
 type Plan struct {
 	Root  string
 	Moves map[string]string // srcAbs -> dstAbs
 }
 
-// BuildPlan analyzes files under root (non-recursive for now) and computes destination moves.
-// If dryRun is true, the plan should still be built fully; only Apply would refrain from changing the FS.
-// STUB for now: return ErrNotImplemented so tests fail.
+// BuildPlan analyzes files under root (non-recursive) and computes destination moves.
+// When dryRun is true, the filesystem must remain untouched (this function only returns the plan).
 func BuildPlan(root string, dryRun bool) (Plan, error) {
-	return Plan{}, ErrNotImplemented
+	if root == "" {
+		return Plan{}, fmt.Errorf("root is required")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return Plan{}, err
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		return Plan{}, err
+	}
+	if !info.IsDir() {
+		return Plan{}, fmt.Errorf("not a directory: %s", absRoot)
+	}
+
+	ents, err := os.ReadDir(absRoot)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	moves := make(map[string]string)
+	for _, e := range ents {
+		if e.IsDir() {
+			// Non-recursive by design (future PR could add recursion).
+			continue
+		}
+		name := e.Name()
+		src := filepath.Join(absRoot, name)
+
+		cl := classifyByExt(name)
+		dstDir := filepath.Join(absRoot, string(cl))
+		dst := filepath.Join(dstDir, name)
+
+		// Skip no-op moves (e.g., already in place, though this shouldn't happen for root files).
+		if src == dst {
+			continue
+		}
+		moves[src] = dst
+	}
+
+	return Plan{
+		Root:  absRoot,
+		Moves: moves,
+	}, nil
 }
 
-// Apply executes the plan: create destination dirs as needed and move files.
-// STUB for now: return ErrNotImplemented so tests fail.
+// Apply executes the plan: create destination dirs and move files with os.Rename.
 func Apply(p Plan) error {
-	return ErrNotImplemented
+	for src, dst := range p.Moves {
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		if err := os.Rename(src, dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// classifyByExt maps filename to a class by (last) extension, case-insensitively.
+func classifyByExt(name string) Class {
+	ext := strings.ToLower(filepath.Ext(name)) // uses only the last extension (e.g., .gz)
+	switch ext {
+	case ".jpg", ".jpeg", ".png", ".gif":
+		return ClassImages
+	case ".pdf", ".doc", ".docx", ".txt", ".md":
+		return ClassDocs
+	case ".mp4", ".mov", ".avi":
+		return ClassVideos
+	default:
+		return ClassOther
+	}
 }

--- a/filesort/internal/sorter/sorter_test.go
+++ b/filesort/internal/sorter/sorter_test.go
@@ -33,13 +33,6 @@ func listDir(t *testing.T, dir string) []string {
 	return names
 }
 
-// Expected classes (to be implemented in #11):
-// images: .jpg .jpeg .png .gif
-// docs:   .pdf .doc .docx .txt .md
-// videos: .mp4 .mov .avi
-// other:  everything else
-// Destination layout: <root>/<class>/<filename>
-
 func TestBuildPlan_DryRunAndApply_BasicLayout(t *testing.T) {
 	root := t.TempDir()
 
@@ -50,57 +43,64 @@ func TestBuildPlan_DryRunAndApply_BasicLayout(t *testing.T) {
 	vid1 := touch(t, root, "clip.MP4")
 	oth1 := touch(t, root, "archive.tar.gz")
 
-	// Build plan (should enumerate moves but not touch FS when dryRun=true)
+	// Build plan (must not touch FS when dryRun=true)
 	p, err := sorter.BuildPlan(root, true)
-	if err == nil {
-		// Because stubs return ErrNotImplemented, we expect err != nil until implementation PR.
-		t.Fatalf("expected failure (not implemented), got nil")
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
 	}
-	_ = p
 
-	// The following assertions describe the *intended* behavior and will be enabled in #11.
-	// They are kept here so the test body is self-documenting.
+	// On-disk layout unchanged:
+	gotRoot := listDir(t, root)
+	wantRoot := []string{"archive.tar.gz", "clip.MP4", "notes.md", "photo.JPG", "pic.png"}
+	if strings.Join(gotRoot, ",") != strings.Join(wantRoot, ",") {
+		t.Fatalf("unexpected root layout after dry-run\nGOT:  %v\nWANT: %v", gotRoot, wantRoot)
+	}
+
+	// Sanity check: planned moves include the expected destinations
+	if len(p.Moves) != 5 {
+		t.Fatalf("expected 5 planned moves, got %d", len(p.Moves))
+	}
 	_ = img1
 	_ = img2
 	_ = doc1
 	_ = vid1
 	_ = oth1
-
-	// After BuildPlan with dryRun=true, on-disk layout must be unchanged:
-	gotRoot := listDir(t, root)
-	// Expect only the original files present (order sorted for stability)
-	wantRoot := []string{"archive.tar.gz", "clip.MP4", "notes.md", "photo.JPG", "pic.png"}
-	if strings.Join(gotRoot, ",") != strings.Join(wantRoot, ",") {
-		t.Logf("GOT:  %v", gotRoot)
-		t.Logf("WANT: %v", wantRoot)
-		// Uncomment once implemented:
-		// t.Fatalf("unexpected root layout after dry-run")
-	}
 }
 
 func TestApply_ExecutesMoves(t *testing.T) {
 	root := t.TempDir()
 
-	_ = touch(t, root, "photo.jpg")
-	_ = touch(t, root, "doc.txt")
-	_ = touch(t, root, "movie.mp4")
-	_ = touch(t, root, "README") // other
+	_ = touch(t, root, "photo.jpg") // images
+	_ = touch(t, root, "doc.txt")   // docs
+	_ = touch(t, root, "movie.mp4") // videos
+	_ = touch(t, root, "README")    // other
 
-	// Build a plan without dry-run, then apply it.
 	p, err := sorter.BuildPlan(root, false)
-	if err == nil {
-		// Expect failure until #11 implements it.
-		t.Fatalf("expected failure (not implemented), got nil")
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	if err := sorter.Apply(p); err != nil {
+		t.Fatalf("apply: %v", err)
 	}
 
-	// When implemented, Apply should create folders and move files:
-	// err = sorter.Apply(p)
-	// if err != nil { t.Fatalf("apply: %v", err) }
+	gotDirs := listDir(t, root)
+	wantDirs := []string{"docs", "images", "other", "videos"}
+	slices.Sort(wantDirs)
+	if strings.Join(gotDirs, ",") != strings.Join(wantDirs, ",") {
+		t.Fatalf("unexpected dirs in root: %v", gotDirs)
+	}
 
-	// wantDirs := []string{"docs", "images", "other", "videos"}
-	// gotDirs := listDir(t, root)
-	// slices.Sort(wantDirs)
-	// if strings.Join(gotDirs, ",") != strings.Join(wantDirs, ",") {
-	// t.Fatalf("unexpected dirs in root: %v", gotDirs)
-	// }
+	// spot-check files exist under expected dirs
+	if _, err := os.Stat(filepath.Join(root, "images", "photo.jpg")); err != nil {
+		t.Fatalf("missing moved image: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "doc.txt")); err != nil {
+		t.Fatalf("missing moved doc: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "videos", "movie.mp4")); err != nil {
+		t.Fatalf("missing moved video: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "other", "README")); err != nil {
+		t.Fatalf("missing moved other: %v", err)
+	}
 }


### PR DESCRIPTION
Implements non-recursive extension-based classification (images/docs/videos/other), plan building, and plan application. Adds a small CLI that accepts `--dry-run` and a root directory. Updates the earlier tests from #10 to assert the intended behavior. Pure stdlib, offline tests.

**Closes #11.**

------
https://chatgpt.com/codex/tasks/task_b_690257cbdea4832f9f743d8d4321a8e2