### PR TITLE
test(weathertape): add failing ingestion and tape rendering tests

### DIFF
--- a/weathertape/internal/forecast/forecast.go
+++ b/weathertape/internal/forecast/forecast.go
@@ -1,0 +1,24 @@
+package forecast
+
+import (
+	"errors"
+	"time"
+)
+
+// Entry models a single hourly forecast row used by the renderer.
+type Entry struct {
+	Time           time.Time
+	TempC          float64
+	PrecipPercent  int
+	WindKPH        float64
+	WindDirection  string
+	SourceFilePath string
+}
+
+// ErrNotImplemented indicates the loader has not been implemented yet.
+var ErrNotImplemented = errors.New("forecast: loader not implemented")
+
+// LoadFile loads forecast data from a JSON/CSV file path and returns normalized entries.
+func LoadFile(path string) ([]Entry, error) {
+	return nil, ErrNotImplemented
+}

--- a/weathertape/internal/forecast/forecast_test.go
+++ b/weathertape/internal/forecast/forecast_test.go
@@ -1,0 +1,52 @@
+package forecast_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pekomon/go-sandbox/weathertape/internal/forecast"
+)
+
+func TestLoadFileSuccess(t *testing.T) {
+	t.Helper()
+
+	path := filepath.Join("..", "..", "testdata", "sample.json")
+	entries, err := forecast.LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile(%q) returned error: %v", path, err)
+	}
+	if len(entries) != 4 {
+		t.Fatalf("LoadFile(%q) returned %d entries; want 4", path, len(entries))
+	}
+
+	first := entries[0]
+	wantTime := time.Date(2025, 2, 10, 9, 0, 0, 0, time.UTC)
+	if !first.Time.Equal(wantTime) {
+		t.Fatalf("first entry time = %s; want %s", first.Time.Format(time.RFC3339), wantTime.Format(time.RFC3339))
+	}
+	if first.TempC != 12.0 {
+		t.Fatalf("first entry TempC = %.1f; want 12.0", first.TempC)
+	}
+	if first.PrecipPercent != 10 {
+		t.Fatalf("first entry PrecipPercent = %d; want 10", first.PrecipPercent)
+	}
+	if first.WindKPH != 8.0 {
+		t.Fatalf("first entry WindKPH = %.1f; want 8.0", first.WindKPH)
+	}
+	if first.WindDirection != "NE" {
+		t.Fatalf("first entry WindDirection = %q; want %q", first.WindDirection, "NE")
+	}
+
+	last := entries[len(entries)-1]
+	if last.TempC != 21.0 {
+		t.Fatalf("last entry TempC = %.1f; want 21.0", last.TempC)
+	}
+}
+
+func TestLoadFileMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.json")
+	if _, err := forecast.LoadFile(path); err == nil {
+		t.Fatalf("LoadFile(%q) returned nil error; want failure for missing file", path)
+	}
+}

--- a/weathertape/internal/tape/tape.go
+++ b/weathertape/internal/tape/tape.go
@@ -1,0 +1,31 @@
+package tape
+
+import (
+	"errors"
+
+	"github.com/pekomon/go-sandbox/weathertape/internal/forecast"
+)
+
+// Units controls whether the tape renders metric or imperial measurements.
+type Units int
+
+const (
+	// UnitsMetric renders °C temperatures and kph wind speeds.
+	UnitsMetric Units = iota
+	// UnitsImperial renders °F temperatures and mph wind speeds.
+	UnitsImperial
+)
+
+// Options configures how the ASCII tape should be rendered.
+type Options struct {
+	Units Units
+	Width int // number of characters used for the bar graph section
+}
+
+// ErrNotImplemented signals the renderer still needs an implementation.
+var ErrNotImplemented = errors.New("tape: renderer not implemented")
+
+// Render builds an ASCII tape using the provided forecast entries.
+func Render(entries []forecast.Entry, opts Options) (string, error) {
+	return "", ErrNotImplemented
+}

--- a/weathertape/internal/tape/tape_test.go
+++ b/weathertape/internal/tape/tape_test.go
@@ -1,0 +1,89 @@
+package tape_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pekomon/go-sandbox/weathertape/internal/forecast"
+	"github.com/pekomon/go-sandbox/weathertape/internal/tape"
+)
+
+func TestRenderMetricTape(t *testing.T) {
+	t.Helper()
+
+	entries := sampleEntries()
+	opts := tape.Options{Units: tape.UnitsMetric, Width: 10}
+	got, err := tape.Render(entries, opts)
+	if err != nil {
+		t.Fatalf("Render(metric) returned error: %v", err)
+	}
+
+	const want = "" +
+		"Hour  Temp  Trend       Precip Wind\n" +
+		"----  ----  ----------  ------ ----\n" +
+		"09:00 12°C  █░░░░░░░░░░   10%  NE8kph\n" +
+		"10:00 15°C  ███░░░░░░░░   40%  E11kph\n" +
+		"11:00 19°C  ███████░░░░   70%  SE20kph\n" +
+		"12:00 21°C  ██████████   15%  S25kph"
+
+	if strings.TrimSpace(got) != want {
+		t.Fatalf("Render(metric) mismatch.\nGot:\n%s\n\nWant:\n%s", got, want)
+	}
+}
+
+func TestRenderImperialTape(t *testing.T) {
+	t.Helper()
+
+	entries := sampleEntries()
+	opts := tape.Options{Units: tape.UnitsImperial, Width: 10}
+	got, err := tape.Render(entries, opts)
+	if err != nil {
+		t.Fatalf("Render(imp) returned error: %v", err)
+	}
+
+	const want = "" +
+		"Hour  Temp  Trend       Precip Wind\n" +
+		"----  ----  ----------  ------ ----\n" +
+		"09:00 54°F  █░░░░░░░░░░   10%  NE5mph\n" +
+		"10:00 59°F  ███░░░░░░░░   40%  E7mph\n" +
+		"11:00 65°F  ███████░░░░   70%  SE12mph\n" +
+		"12:00 70°F  ██████████   15%  S16mph"
+
+	if strings.TrimSpace(got) != want {
+		t.Fatalf("Render(imp) mismatch.\nGot:\n%s\n\nWant:\n%s", got, want)
+	}
+}
+
+func sampleEntries() []forecast.Entry {
+	return []forecast.Entry{
+		{
+			Time:          time.Date(2025, 2, 10, 9, 0, 0, 0, time.UTC),
+			TempC:         12.0,
+			PrecipPercent: 10,
+			WindKPH:       8,
+			WindDirection: "NE",
+		},
+		{
+			Time:          time.Date(2025, 2, 10, 10, 0, 0, 0, time.UTC),
+			TempC:         15.0,
+			PrecipPercent: 40,
+			WindKPH:       11,
+			WindDirection: "E",
+		},
+		{
+			Time:          time.Date(2025, 2, 10, 11, 0, 0, 0, time.UTC),
+			TempC:         18.5,
+			PrecipPercent: 70,
+			WindKPH:       20,
+			WindDirection: "SE",
+		},
+		{
+			Time:          time.Date(2025, 2, 10, 12, 0, 0, 0, time.UTC),
+			TempC:         21.0,
+			PrecipPercent: 15,
+			WindKPH:       25,
+			WindDirection: "S",
+		},
+	}
+}

--- a/weathertape/testdata/sample.json
+++ b/weathertape/testdata/sample.json
@@ -1,0 +1,30 @@
+[
+  {
+    "hour": "2025-02-10T09:00:00Z",
+    "temp_c": 12.0,
+    "precip_pct": 10,
+    "wind_kph": 8.0,
+    "wind_dir": "NE"
+  },
+  {
+    "hour": "2025-02-10T10:00:00Z",
+    "temp_c": 15.0,
+    "precip_pct": 40,
+    "wind_kph": 11.0,
+    "wind_dir": "E"
+  },
+  {
+    "hour": "2025-02-10T11:00:00Z",
+    "temp_c": 18.5,
+    "precip_pct": 70,
+    "wind_kph": 20.0,
+    "wind_dir": "SE"
+  },
+  {
+    "hour": "2025-02-10T12:00:00Z",
+    "temp_c": 21.0,
+    "precip_pct": 15,
+    "wind_kph": 25.0,
+    "wind_dir": "S"
+  }
+]


### PR DESCRIPTION
## Summary
- add forecast/tape packages with ErrNotImplemented stubs so tests compile
- add deterministic fixtures and table-driven tests for loader + renderer
- go test ./... fails until issue #59 implements the loader/renderer logic

Closes #58.
