### PR TITLE
test(thumbforge): add failing tests

### DIFF
--- a/thumbforge/internal/cli/parse.go
+++ b/thumbforge/internal/cli/parse.go
@@ -1,0 +1,8 @@
+package cli
+
+import "github.com/pekomon/go-sandbox/thumbforge/internal/thumbforge"
+
+// ParseArgs parses CLI arguments into a ThumbForge configuration.
+func ParseArgs(args []string) (thumbforge.Config, error) {
+	return thumbforge.Config{}, thumbforge.ErrNotImplemented
+}

--- a/thumbforge/internal/cli/parse_test.go
+++ b/thumbforge/internal/cli/parse_test.go
@@ -1,0 +1,91 @@
+package cli_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/thumbforge/internal/cli"
+	"github.com/pekomon/go-sandbox/thumbforge/internal/thumbforge"
+)
+
+func TestParseArgs(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{
+		"--in", inDir,
+		"--out", outDir,
+		"--size", "120x90",
+		"--format", "jpg",
+		"--crop",
+	}
+
+	cfg, err := cli.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := thumbforge.Config{
+		InputDir:  inDir,
+		OutputDir: outDir,
+		Size:      thumbforge.Size{Width: 120, Height: 90},
+		Format:    "jpg",
+		Crop:      true,
+	}
+
+	if cfg != want {
+		t.Fatalf("unexpected config: got %+v want %+v", cfg, want)
+	}
+}
+
+func TestParseArgsMissingRequired(t *testing.T) {
+	args := []string{"--size", "120x90"}
+
+	_, err := cli.ParseArgs(args)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParseArgsInvalidSize(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{"--in", inDir, "--out", outDir, "--size", "abc"}
+
+	_, err := cli.ParseArgs(args)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParseArgsDefaults(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{"--in", inDir, "--out", outDir, "--size", "120x90"}
+
+	cfg, err := cli.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Format == "" {
+		t.Fatalf("expected default format")
+	}
+	if cfg.InputDir != inDir || cfg.OutputDir != outDir {
+		t.Fatalf("unexpected directories")
+	}
+	if cfg.Size != (thumbforge.Size{Width: 120, Height: 90}) {
+		t.Fatalf("unexpected size")
+	}
+}
+
+func TestParseArgsRejectsMissingInputDir(t *testing.T) {
+	args := []string{"--out", os.TempDir(), "--size", "120x90"}
+
+	_, err := cli.ParseArgs(args)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/thumbforge/internal/thumbforge/batch_test.go
+++ b/thumbforge/internal/thumbforge/batch_test.go
@@ -1,0 +1,63 @@
+package thumbforge_test
+
+import (
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pekomon/go-sandbox/thumbforge/internal/thumbforge"
+)
+
+func TestGenerateBatch(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	if err := writePNG(filepath.Join(inDir, "one.png"), 4, 4); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	if err := writePNG(filepath.Join(inDir, "two.png"), 8, 8); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+
+	cfg := thumbforge.Config{
+		InputDir:  inDir,
+		OutputDir: outDir,
+		Size:      thumbforge.Size{Width: 2, Height: 2},
+		Format:    "png",
+	}
+
+	result, err := thumbforge.Generate(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Count != 2 {
+		t.Fatalf("unexpected count: got %d want 2", result.Count)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "one.png")); err != nil {
+		t.Fatalf("expected thumbnail for one.png: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "two.png")); err != nil {
+		t.Fatalf("expected thumbnail for two.png: %v", err)
+	}
+}
+
+func writePNG(path string, width, height int) error {
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 0x33, G: 0x66, B: 0x99, A: 0xff})
+		}
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return png.Encode(file, img)
+}

--- a/thumbforge/internal/thumbforge/config.go
+++ b/thumbforge/internal/thumbforge/config.go
@@ -1,0 +1,36 @@
+package thumbforge
+
+import "errors"
+
+// ErrNotImplemented is returned by stubbed ThumbForge functions in the tests-first PR.
+var ErrNotImplemented = errors.New("thumbforge: not implemented")
+
+// Size represents a target thumbnail size in pixels.
+type Size struct {
+	Width  int
+	Height int
+}
+
+// Config defines the batch thumbnail generation settings.
+type Config struct {
+	InputDir  string
+	OutputDir string
+	Size      Size
+	Format    string
+	Crop      bool
+}
+
+// Result reports summary data from a batch run.
+type Result struct {
+	Count int
+}
+
+// ParseSize parses a WxH size string (e.g. 320x240).
+func ParseSize(input string) (Size, error) {
+	return Size{}, ErrNotImplemented
+}
+
+// Generate produces thumbnails based on the supplied configuration.
+func Generate(cfg Config) (Result, error) {
+	return Result{}, ErrNotImplemented
+}

--- a/thumbforge/internal/thumbforge/config_test.go
+++ b/thumbforge/internal/thumbforge/config_test.go
@@ -1,0 +1,55 @@
+package thumbforge_test
+
+import (
+	"testing"
+
+	"github.com/pekomon/go-sandbox/thumbforge/internal/thumbforge"
+)
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		want     thumbforge.Size
+		wantErr  bool
+	}{
+		{
+			name:  "valid",
+			input: "320x240",
+			want: thumbforge.Size{Width: 320, Height: 240},
+		},
+		{
+			name:    "missing_separator",
+			input:   "320-240",
+			wantErr: true,
+		},
+		{
+			name:    "zero_dimension",
+			input:   "0x240",
+			wantErr: true,
+		},
+		{
+			name:    "non_numeric",
+			input:   "axb",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := thumbforge.ParseSize(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected size: got %+v want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add failing tests for CLI arg parsing
- add failing tests for batch generation and size parsing
- introduce stub APIs to define the expected behavior

Closes #70.