### PR TITLE
test(thumbforge): extend cli size/format coverage

### DIFF
--- a/thumbforge/internal/cli/parse_test.go
+++ b/thumbforge/internal/cli/parse_test.go
@@ -38,8 +38,55 @@ func TestParseArgs(t *testing.T) {
 	}
 }
 
+func TestParseArgsWithWidthHeight(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{
+		"--in", inDir,
+		"--out", outDir,
+		"--width", "80",
+		"--height", "60",
+		"--format", "png",
+	}
+
+	cfg, err := cli.ParseArgs(args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := thumbforge.Config{
+		InputDir:  inDir,
+		OutputDir: outDir,
+		Size:      thumbforge.Size{Width: 80, Height: 60},
+		Format:    "png",
+	}
+
+	if cfg != want {
+		t.Fatalf("unexpected config: got %+v want %+v", cfg, want)
+	}
+}
+
 func TestParseArgsMissingRequired(t *testing.T) {
 	args := []string{"--size", "120x90"}
+
+	_, err := cli.ParseArgs(args)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParseArgsRejectsMixedSizeFlags(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{
+		"--in", inDir,
+		"--out", outDir,
+		"--size", "120x90",
+		"--width", "120",
+		"--height", "90",
+	}
 
 	_, err := cli.ParseArgs(args)
 	if err == nil {
@@ -52,6 +99,23 @@ func TestParseArgsInvalidSize(t *testing.T) {
 	outDir := t.TempDir()
 
 	args := []string{"--in", inDir, "--out", outDir, "--size", "abc"}
+
+	_, err := cli.ParseArgs(args)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestParseArgsInvalidFormat(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{
+		"--in", inDir,
+		"--out", outDir,
+		"--size", "120x90",
+		"--format", "gif",
+	}
 
 	_, err := cli.ParseArgs(args)
 	if err == nil {
@@ -78,6 +142,22 @@ func TestParseArgsDefaults(t *testing.T) {
 	}
 	if cfg.Size != (thumbforge.Size{Width: 120, Height: 90}) {
 		t.Fatalf("unexpected size")
+	}
+}
+
+func TestParseArgsMissingWidthHeight(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	args := []string{
+		"--in", inDir,
+		"--out", outDir,
+		"--width", "120",
+	}
+
+	_, err := cli.ParseArgs(args)
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }
 

--- a/thumbforge/internal/thumbforge/batch_test.go
+++ b/thumbforge/internal/thumbforge/batch_test.go
@@ -45,6 +45,23 @@ func TestGenerateBatch(t *testing.T) {
 	}
 }
 
+func TestGenerateEmptyInput(t *testing.T) {
+	inDir := t.TempDir()
+	outDir := t.TempDir()
+
+	cfg := thumbforge.Config{
+		InputDir:  inDir,
+		OutputDir: outDir,
+		Size:      thumbforge.Size{Width: 2, Height: 2},
+		Format:    "png",
+	}
+
+	_, err := thumbforge.Generate(cfg)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
 func writePNG(path string, width, height int) error {
 	img := image.NewRGBA(image.Rect(0, 0, width, height))
 	for y := 0; y < height; y++ {


### PR DESCRIPTION
## Summary
- add tests for width/height CLI size flags and size/format validation
- assert empty input directories are rejected by batch generation

Refs #72.