### PR TITLE
test(speedpads): scaffold module and failing state-machine tests

### DIFF
--- a/.github/workflows/speedpads.yml
+++ b/.github/workflows/speedpads.yml
@@ -1,0 +1,56 @@
+name: speedpads
+
+on:
+  push:
+    branches: [ "main", "feat/**", "infra/**", "fix/**", "docs/**", "test/**" ]
+    paths:
+      - "speedpads/**"
+      - "Makefile"
+      - "README.md"
+      - "agents.md"
+      - ".github/workflows/speedpads.yml"
+  pull_request:
+    branches: [ "main", "feat/**", "infra/**", "fix/**", "docs/**", "test/**" ]
+    paths:
+      - "speedpads/**"
+      - "Makefile"
+      - "README.md"
+      - "agents.md"
+      - ".github/workflows/speedpads.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: speedpads
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go 1.25.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Go env
+        run: go env
+
+      - name: Run tests with coverage
+        run: |
+          set -e
+          go test ./... -coverprofile=cover.out -covermode=atomic | tee ../speedpads-test-output.txt
+
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: speedpads-coverage
+          path: speedpads/cover.out
+          if-no-files-found: warn
+
+      - name: Upload test output
+        uses: actions/upload-artifact@v4
+        with:
+          name: speedpads-test-output
+          path: speedpads-test-output.txt
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /dungeondice/dungeondice
 /triviagoblin/triviagoblin
 /brickbreaker/brickbreaker
+/speedpads/speedpads
 
 # Go
 *.exe

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SUBPROJECTS := todo-cli guessr filesort snake brickbreaker memesweeper weathertape thumbforge dungeondice triviagoblin
+SUBPROJECTS := todo-cli guessr filesort snake brickbreaker speedpads memesweeper weathertape thumbforge dungeondice triviagoblin
 
 .PHONY: deps-all build-all test-all cover-all clean-all clean-local-binaries list
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Multi-project Go repository (Go baseline: 1.25). Each subproject lives in its ow
 - **filesort** — Directory sorter that buckets files by type with a dry-run preview.
 - **snake** — Ebiten-based arcade snake clone with instant restarts and score overlay.
 - **brickbreaker** — Arkanoid-style Ebiten game with deterministic gameplay tests, three built-in levels, and a level-by-level speed ramp.
+- **speedpads** — Speden Spelit inspired memory-speed game scaffold with deterministic sequence-state tests and an Ebiten placeholder shell.
 - **memesweeper** — Ebiten puzzler inspired by Minesweeper with meme tiles, flags, and difficulty presets.
 - **weathertape** — Terminal weather dashboard that renders ASCII “tape” forecasts from JSON data sources.
 - **thumbforge** — CLI for batch thumbnail generation: resize images offline and export fixed-size assets.

--- a/agents.md
+++ b/agents.md
@@ -5,7 +5,7 @@ Language: English only for code, comments, READMEs, commit messages.
 
 ## Repository shape
 - Multi-project Go repo; **each subproject is its own module** (has its own `go.mod`).
-- Current subprojects: `todo-cli/`, `guessr/`, `filesort/`, `snake/`, `brickbreaker/`, `memesweeper/`, `weathertape/`, `thumbforge/`, `dungeondice/`, `triviagoblin/`.
+- Current subprojects: `todo-cli/`, `guessr/`, `filesort/`, `snake/`, `brickbreaker/`, `speedpads/`, `memesweeper/`, `weathertape/`, `thumbforge/`, `dungeondice/`, `triviagoblin/`.
 - Root contains top-level docs plus a coordinating `Makefile` for list/build/test/cover/clean loops across subprojects.
 
 ## Go & toolchain

--- a/speedpads/.gitignore
+++ b/speedpads/.gitignore
@@ -1,0 +1,6 @@
+*.exe
+*.test
+*.out
+*.cover
+coverage*.out
+tmp/

--- a/speedpads/Makefile
+++ b/speedpads/Makefile
@@ -1,0 +1,25 @@
+APP := speedpads
+
+.PHONY: deps build test cover clean ensure-tidy
+
+deps:
+	@go mod tidy
+
+build: deps
+	@echo "Building $(APP)"
+	@mkdir -p bin
+	@go build -o bin/$(APP) ./cmd/$(APP)
+
+test: deps
+	@go test ./...
+
+cover: deps
+	@go test ./... -coverprofile=cover.out -covermode=atomic
+	@go tool cover -func=cover.out | tail -n +1
+
+clean:
+	@rm -rf bin cover.out
+
+ensure-tidy:
+	@go mod tidy
+	@git diff --quiet -- go.mod go.sum || (echo "go.mod/go.sum not tidy"; exit 1)

--- a/speedpads/README.md
+++ b/speedpads/README.md
@@ -1,0 +1,66 @@
+# Speedpads
+
+Speedpads is a Speden Spelit inspired memory-speed game scaffold built with Ebiten. This first PR intentionally lands the module structure, root wiring, CI, and deterministic state-machine tests before the real game loop is implemented.
+
+The current binary opens a placeholder window so the module builds cleanly while the core show-phase and input-phase behavior is still being driven by red tests.
+
+## Installation
+
+Requirements: Go 1.25+, `make`, and a desktop graphics environment for Ebiten.
+
+```bash
+cd speedpads
+make build
+```
+
+Or build directly:
+
+```bash
+cd speedpads
+go build -o bin/speedpads ./cmd/speedpads
+```
+
+## Usage
+
+Run the current scaffold:
+
+```bash
+cd speedpads
+./bin/speedpads
+```
+
+Or run without building:
+
+```bash
+cd speedpads
+go run ./cmd/speedpads
+```
+
+Planned controls:
+- `Space` to start
+- `D`, `F`, `J`, `K` for the four pads
+- `R` to restart after game over
+- `Esc` to quit
+
+## Testing & Coverage
+
+This module is intentionally tests-first at the moment. The gameplay tests define the expected deterministic sequence, show phase, input phase, watchdog timeout, and round progression behavior.
+
+```bash
+cd speedpads
+make test
+make cover
+```
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| `0` | Clean exit from the window. |
+| `1` | Initialization or runtime failure reported via stderr. |
+
+## Development notes
+
+- Rendering uses [Ebiten v2](https://ebiten.org/) to match the existing GUI games in this repository.
+- Core game rules live in `internal/game`.
+- Follow the shared repository conventions in [../agents.md](../agents.md).

--- a/speedpads/cmd/speedpads/main.go
+++ b/speedpads/cmd/speedpads/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"image/color"
+	"log"
+
+	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
+	"github.com/hajimehoshi/ebiten/v2/inpututil"
+
+	"github.com/pekomon/go-sandbox/speedpads/internal/game"
+)
+
+var backgroundColor = color.RGBA{0x10, 0x12, 0x18, 0xff}
+
+type app struct {
+	state *game.State
+}
+
+func newApp() (*app, error) {
+	st, err := game.New(game.DefaultConfig())
+	if err != nil {
+		return nil, err
+	}
+	return &app{state: st}, nil
+}
+
+func (a *app) Update() error {
+	if inpututil.IsKeyJustPressed(ebiten.KeyEscape) {
+		return ebiten.Termination
+	}
+	return nil
+}
+
+func (a *app) Draw(screen *ebiten.Image) {
+	screen.Fill(backgroundColor)
+	ebitenutil.DebugPrint(screen, "Speedpads scaffold\n\nGameplay loop arrives in the follow-up feature PR.\n\nPlanned controls:\n- Space: start\n- D/F/J/K: input pads\n- R: restart after game over\n- Esc: quit")
+}
+
+func (a *app) Layout(int, int) (int, int) {
+	return int(a.state.Width), int(a.state.Height)
+}
+
+func main() {
+	app, err := newApp()
+	if err != nil {
+		log.Fatalf("init speedpads: %v", err)
+	}
+
+	ebiten.SetWindowTitle("Speedpads")
+	ebiten.SetWindowSize(int(app.state.Width), int(app.state.Height))
+	ebiten.SetWindowResizingMode(ebiten.WindowResizingModeDisabled)
+
+	if err := ebiten.RunGame(app); err != nil && !errors.Is(err, ebiten.Termination) {
+		log.Fatal(err)
+	}
+}

--- a/speedpads/go.mod
+++ b/speedpads/go.mod
@@ -1,0 +1,14 @@
+module github.com/pekomon/go-sandbox/speedpads
+
+go 1.25
+
+require github.com/hajimehoshi/ebiten/v2 v2.9.3
+
+require (
+	github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 // indirect
+	github.com/ebitengine/hideconsole v1.0.0 // indirect
+	github.com/ebitengine/purego v0.9.0 // indirect
+	github.com/jezek/xgb v1.1.1 // indirect
+	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
+)

--- a/speedpads/go.sum
+++ b/speedpads/go.sum
@@ -1,0 +1,16 @@
+github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 h1:+kz5iTT3L7uU+VhlMfTb8hHcxLO3TlaELlX8wa4XjA0=
+github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1/go.mod h1:lKJoeixeJwnFmYsBny4vvCJGVFc3aYDalhuDsfZzWHI=
+github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=
+github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
+github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
+github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/hajimehoshi/ebiten/v2 v2.9.3 h1:i2xYZ7GUk7/Bwa4CUxI/cZq+zrDrYCHGgwHLO61/Dok=
+github.com/hajimehoshi/ebiten/v2 v2.9.3/go.mod h1:DAt4tnkYYpCvu3x9i1X/nK/vOruNXIlYq/tBXxnhrXM=
+github.com/jezek/xgb v1.1.1 h1:bE/r8ZZtSv7l9gk6nU0mYx51aXrvnyb44892TwSaqS4=
+github.com/jezek/xgb v1.1.1/go.mod h1:nrhwO0FX/enq75I7Y7G8iN1ubpSGZEiA3v9e9GyRFlk=
+golang.org/x/image v0.31.0 h1:mLChjE2MV6g1S7oqbXC0/UcKijjm5fnJLUYKIYrLESA=
+golang.org/x/image v0.31.0/go.mod h1:R9ec5Lcp96v9FTF+ajwaH3uGxPH4fKfHHAVbUILxghA=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/speedpads/internal/game/game.go
+++ b/speedpads/internal/game/game.go
@@ -1,0 +1,105 @@
+package game
+
+import (
+	"errors"
+	"math/rand"
+)
+
+type Phase int
+
+const (
+	PhaseAttract Phase = iota
+	PhaseShowing
+	PhaseInput
+	PhaseGameOver
+)
+
+type Input struct {
+	Start   bool
+	Restart bool
+	Pad     int
+	Press   bool
+}
+
+type Config struct {
+	Width             float64
+	Height            float64
+	PadCount          int
+	StartLength       int
+	ShowTicks         int
+	GapTicks          int
+	InputTimeoutTicks int
+	Seed              int64
+}
+
+type State struct {
+	Width             float64
+	Height            float64
+	PadCount          int
+	Phase             Phase
+	Round             int
+	Score             int
+	Sequence          []int
+	ShowIndex         int
+	InputIndex        int
+	LitPad            int
+	ShowTicks         int
+	GapTicks          int
+	InputTimeoutTicks int
+	PhaseTick         int
+	WatchdogTick      int
+
+	baseShowTicks         int
+	baseGapTicks          int
+	baseInputTimeoutTicks int
+	startLength           int
+	rng                   *rand.Rand
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Width:             640,
+		Height:            360,
+		PadCount:          4,
+		StartLength:       2,
+		ShowTicks:         24,
+		GapTicks:          14,
+		InputTimeoutTicks: 180,
+		Seed:              1,
+	}
+}
+
+func New(cfg Config) (*State, error) {
+	if cfg.Width <= 0 || cfg.Height <= 0 {
+		return nil, errors.New("invalid dimensions")
+	}
+	if cfg.PadCount < 2 {
+		return nil, errors.New("invalid pad count")
+	}
+	if cfg.StartLength < 1 {
+		return nil, errors.New("invalid start length")
+	}
+	if cfg.ShowTicks < 1 || cfg.GapTicks < 1 || cfg.InputTimeoutTicks < 1 {
+		return nil, errors.New("invalid timing configuration")
+	}
+
+	return &State{
+		Width:                 cfg.Width,
+		Height:                cfg.Height,
+		PadCount:              cfg.PadCount,
+		Phase:                 PhaseAttract,
+		LitPad:                -1,
+		ShowTicks:             cfg.ShowTicks,
+		GapTicks:              cfg.GapTicks,
+		InputTimeoutTicks:     cfg.InputTimeoutTicks,
+		baseShowTicks:         cfg.ShowTicks,
+		baseGapTicks:          cfg.GapTicks,
+		baseInputTimeoutTicks: cfg.InputTimeoutTicks,
+		startLength:           cfg.StartLength,
+		rng:                   rand.New(rand.NewSource(cfg.Seed)),
+	}, nil
+}
+
+func (s *State) Step(Input) error {
+	return nil
+}

--- a/speedpads/internal/game/game_test.go
+++ b/speedpads/internal/game/game_test.go
@@ -1,0 +1,171 @@
+package game_test
+
+import (
+	"testing"
+
+	"github.com/pekomon/go-sandbox/speedpads/internal/game"
+)
+
+func newConfig() game.Config {
+	cfg := game.DefaultConfig()
+	cfg.ShowTicks = 2
+	cfg.GapTicks = 1
+	cfg.InputTimeoutTicks = 5
+	cfg.Seed = 7
+	return cfg
+}
+
+func newState(t *testing.T) *game.State {
+	t.Helper()
+
+	st, err := game.New(newConfig())
+	if err != nil {
+		t.Fatalf("game.New: %v", err)
+	}
+	return st
+}
+
+func stepMany(t *testing.T, st *game.State, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := st.Step(game.Input{}); err != nil {
+			t.Fatalf("Step %d: %v", i, err)
+		}
+	}
+}
+
+func TestNewStartsInAttractPhase(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+
+	if st.Phase != game.PhaseAttract {
+		t.Fatalf("phase = %v, want %v", st.Phase, game.PhaseAttract)
+	}
+	if st.Round != 0 {
+		t.Fatalf("round = %d, want 0", st.Round)
+	}
+	if st.LitPad != -1 {
+		t.Fatalf("lit pad = %d, want -1", st.LitPad)
+	}
+	if len(st.Sequence) != 0 {
+		t.Fatalf("sequence length = %d, want 0", len(st.Sequence))
+	}
+}
+
+func TestStartBeginsShowingDeterministicSequence(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+	if err := st.Step(game.Input{Start: true}); err != nil {
+		t.Fatalf("Step start: %v", err)
+	}
+
+	if st.Phase != game.PhaseShowing {
+		t.Fatalf("phase = %v, want %v", st.Phase, game.PhaseShowing)
+	}
+	if st.Round != 1 {
+		t.Fatalf("round = %d, want 1", st.Round)
+	}
+	if got, want := len(st.Sequence), 2; got != want {
+		t.Fatalf("sequence length = %d, want %d", got, want)
+	}
+	wantSequence := []int{2, 2}
+	for i, want := range wantSequence {
+		if st.Sequence[i] != want {
+			t.Fatalf("sequence[%d] = %d, want %d", i, st.Sequence[i], want)
+		}
+	}
+	if st.LitPad != wantSequence[0] {
+		t.Fatalf("lit pad = %d, want %d", st.LitPad, wantSequence[0])
+	}
+}
+
+func TestShowPhaseTransitionsToInput(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+	if err := st.Step(game.Input{Start: true}); err != nil {
+		t.Fatalf("Step start: %v", err)
+	}
+
+	// Two sequence items with show/gap timing should eventually finish the show phase.
+	stepMany(t, st, 6)
+
+	if st.Phase != game.PhaseInput {
+		t.Fatalf("phase = %v, want %v", st.Phase, game.PhaseInput)
+	}
+	if st.InputIndex != 0 {
+		t.Fatalf("input index = %d, want 0", st.InputIndex)
+	}
+	if st.LitPad != -1 {
+		t.Fatalf("lit pad = %d, want -1 in input phase", st.LitPad)
+	}
+}
+
+func TestCorrectSequenceAdvancesRoundAndShortensTiming(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+	initialShowTicks := st.ShowTicks
+	initialGapTicks := st.GapTicks
+
+	if err := st.Step(game.Input{Start: true}); err != nil {
+		t.Fatalf("Step start: %v", err)
+	}
+	stepMany(t, st, 6)
+
+	for _, pad := range st.Sequence {
+		if err := st.Step(game.Input{Pad: pad, Press: true}); err != nil {
+			t.Fatalf("Step correct pad %d: %v", pad, err)
+		}
+	}
+
+	if st.Phase != game.PhaseShowing {
+		t.Fatalf("phase = %v, want %v after clearing round", st.Phase, game.PhaseShowing)
+	}
+	if st.Round != 2 {
+		t.Fatalf("round = %d, want 2", st.Round)
+	}
+	if got, want := len(st.Sequence), 3; got != want {
+		t.Fatalf("sequence length = %d, want %d", got, want)
+	}
+	if st.ShowTicks >= initialShowTicks {
+		t.Fatalf("show ticks = %d, want < %d after ramp", st.ShowTicks, initialShowTicks)
+	}
+	if st.GapTicks >= initialGapTicks {
+		t.Fatalf("gap ticks = %d, want < %d after ramp", st.GapTicks, initialGapTicks)
+	}
+}
+
+func TestWrongInputEndsGame(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+	if err := st.Step(game.Input{Start: true}); err != nil {
+		t.Fatalf("Step start: %v", err)
+	}
+	stepMany(t, st, 6)
+
+	if err := st.Step(game.Input{Pad: 0, Press: true}); err != nil {
+		t.Fatalf("Step wrong pad: %v", err)
+	}
+	if st.Phase != game.PhaseGameOver {
+		t.Fatalf("phase = %v, want %v after wrong input", st.Phase, game.PhaseGameOver)
+	}
+}
+
+func TestWatchdogTimeoutEndsGame(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+	if err := st.Step(game.Input{Start: true}); err != nil {
+		t.Fatalf("Step start: %v", err)
+	}
+	stepMany(t, st, 6)
+	stepMany(t, st, st.InputTimeoutTicks)
+
+	if st.Phase != game.PhaseGameOver {
+		t.Fatalf("phase = %v, want %v after watchdog timeout", st.Phase, game.PhaseGameOver)
+	}
+}


### PR DESCRIPTION
## Summary
- scaffold the new `speedpads/` module with Makefile, README, CI workflow, and a placeholder Ebiten desktop shell
- wire `speedpads` into the repo root docs, automation, and ignore rules
- add deterministic failing tests in `internal/game` for start/show/input flow, wrong-input failure, watchdog timeout, and round-to-round timing ramp

## Dependency note
- use `github.com/hajimehoshi/ebiten/v2` for the desktop shell to match the existing GUI games in this repo
- keep the core state machine contract in `internal/game` so the failing tests stay offline and deterministic

## Testing
- `cd speedpads && GOCACHE=/tmp/codex-gocache go build ./cmd/speedpads`
- `cd speedpads && GOCACHE=/tmp/codex-gocache go test ./...` *(expected to fail in this tests-first PR)*

Refs #123.