### PR TITLE
feat(speedpads): cut playback on first input

### DIFF
--- a/speedpads/internal/game/game.go
+++ b/speedpads/internal/game/game.go
@@ -115,6 +115,11 @@ func (s *State) Step(in Input) error {
 			return s.beginRound(true)
 		}
 	case PhaseShowing:
+		if in.Press {
+			s.startInputPhase()
+			s.advanceInputPhase(in)
+			return nil
+		}
 		s.advanceShowPhase()
 		if s.Phase == PhaseInput {
 			if in.Press {
@@ -235,6 +240,14 @@ func (s *State) advanceShowPhase() {
 	}
 
 	s.LitPad = s.Sequence[s.ShowIndex]
+}
+
+func (s *State) startInputPhase() {
+	s.Phase = PhaseInput
+	s.InputIndex = 0
+	s.WatchdogTick = 0
+	s.PhaseTick = 0
+	s.LitPad = -1
 }
 
 func (s *State) advanceInputPhase(in Input) {

--- a/speedpads/internal/game/game_test.go
+++ b/speedpads/internal/game/game_test.go
@@ -129,7 +129,7 @@ func TestInputOnShowPhaseBoundaryIsAccepted(t *testing.T) {
 	}
 }
 
-func TestEarlyInputDuringShowPhaseIsIgnored(t *testing.T) {
+func TestEarlyInputDuringShowPhaseCutsToInput(t *testing.T) {
 	t.Parallel()
 
 	st := newState(t)
@@ -142,16 +142,35 @@ func TestEarlyInputDuringShowPhaseIsIgnored(t *testing.T) {
 		t.Fatalf("Step early press: %v", err)
 	}
 
-	stepMany(t, st, 5)
-
 	if st.Phase != game.PhaseInput {
-		t.Fatalf("phase = %v, want %v after ignored early press", st.Phase, game.PhaseInput)
+		t.Fatalf("phase = %v, want %v after cutting playback", st.Phase, game.PhaseInput)
 	}
-	if st.InputIndex != 0 {
-		t.Fatalf("input index = %d, want 0 after ignored early press", st.InputIndex)
+	if st.InputIndex != 1 {
+		t.Fatalf("input index = %d, want 1 after cutting playback", st.InputIndex)
 	}
-	if st.Score != 0 {
-		t.Fatalf("score = %d, want 0 after ignored early press", st.Score)
+	if st.Score != 1 {
+		t.Fatalf("score = %d, want 1 after cutting playback", st.Score)
+	}
+	if st.LitPad != firstPad {
+		t.Fatalf("lit pad = %d, want %d after cutting playback", st.LitPad, firstPad)
+	}
+}
+
+func TestWrongEarlyInputDuringShowPhaseEndsGame(t *testing.T) {
+	t.Parallel()
+
+	st := newState(t)
+	if err := st.Step(game.Input{Start: true}); err != nil {
+		t.Fatalf("Step start: %v", err)
+	}
+
+	wrongPad := (st.Sequence[0] + 1) % st.PadCount
+	if err := st.Step(game.Input{Pad: wrongPad, Press: true}); err != nil {
+		t.Fatalf("Step wrong early press: %v", err)
+	}
+
+	if st.Phase != game.PhaseGameOver {
+		t.Fatalf("phase = %v, want %v after wrong early press", st.Phase, game.PhaseGameOver)
 	}
 }
 


### PR DESCRIPTION
## Summary
- cut remaining sequence playback as soon as the player presses a pad during the show phase
- treat that first press as the first real input instead of forcing the player to wait for the full replay
- add focused tests covering correct and incorrect early-input behavior during playback

## Why
After merging the playable core loop, the remaining rough edge was that the game ignored presses made during playback except on the exact show-to-input boundary. In longer sequences this felt like missed input. This change makes the rule explicit: the player can interrupt playback by starting their answer.

## Impact
- gameplay is more forgiving because the player no longer has to wait for the entire replay to finish
- the first press during playback immediately enters input mode
- a wrong early press still fails immediately, which keeps the rules consistent

## Testing
- `cd speedpads && GOCACHE=/tmp/codex-gocache go test ./...`
- `cd speedpads && GOCACHE=/tmp/codex-gocache go build ./cmd/speedpads`

Refs #123.