### PR TITLE
feat(speedpads): add playback audio cues

### DIFF
--- a/speedpads/cmd/speedpads/main.go
+++ b/speedpads/cmd/speedpads/main.go
@@ -1,17 +1,22 @@
 package main
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"image/color"
 	"log"
+	"math"
 
 	"github.com/hajimehoshi/ebiten/v2"
+	"github.com/hajimehoshi/ebiten/v2/audio"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 
 	"github.com/pekomon/go-sandbox/speedpads/internal/game"
 )
+
+const sampleRate = 44100
 
 var backgroundColor = color.RGBA{0x10, 0x12, 0x18, 0xff}
 
@@ -30,7 +35,18 @@ var dimPadColors = []color.RGBA{
 }
 
 type app struct {
-	state *game.State
+	state       *game.State
+	audio       *audio.Context
+	padSounds   []*audio.Player
+	gameOver    *audio.Player
+	lastLitPad  int
+	lastPhase   game.Phase
+}
+
+type soundSpec struct {
+	frequency float64
+	duration  float64
+	volume    float64
 }
 
 func newApp() (*app, error) {
@@ -38,7 +54,25 @@ func newApp() (*app, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &app{state: st}, nil
+
+	ctx := audio.NewContext(sampleRate)
+	padSounds, err := newPadPlayers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	gameOver, err := newGameOverPlayer(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &app{
+		state:      st,
+		audio:      ctx,
+		padSounds:  padSounds,
+		gameOver:   gameOver,
+		lastLitPad: st.LitPad,
+		lastPhase:  st.Phase,
+	}, nil
 }
 
 func (a *app) Update() error {
@@ -67,7 +101,12 @@ func (a *app) Update() error {
 		in.Press = true
 	}
 
-	return a.state.Step(in)
+	if err := a.state.Step(in); err != nil {
+		return err
+	}
+
+	a.playAudioEvents()
+	return nil
 }
 
 func (a *app) Draw(screen *ebiten.Image) {
@@ -113,6 +152,99 @@ func main() {
 	if err := ebiten.RunGame(app); err != nil && !errors.Is(err, ebiten.Termination) {
 		log.Fatal(err)
 	}
+}
+
+func newPadPlayers(ctx *audio.Context) ([]*audio.Player, error) {
+	specs := []soundSpec{
+		{frequency: 392, duration: 0.08, volume: 0.18},
+		{frequency: 493.88, duration: 0.08, volume: 0.18},
+		{frequency: 587.33, duration: 0.08, volume: 0.18},
+		{frequency: 783.99, duration: 0.08, volume: 0.18},
+	}
+
+	players := make([]*audio.Player, 0, len(specs))
+	for _, spec := range specs {
+		player, err := newTonePlayer(ctx, []soundSpec{spec})
+		if err != nil {
+			return nil, err
+		}
+		players = append(players, player)
+	}
+
+	return players, nil
+}
+
+func newGameOverPlayer(ctx *audio.Context) (*audio.Player, error) {
+	return newTonePlayer(ctx, []soundSpec{
+		{frequency: 220, duration: 0.12, volume: 0.20},
+		{frequency: 174.61, duration: 0.12, volume: 0.18},
+		{frequency: 130.81, duration: 0.18, volume: 0.18},
+	})
+}
+
+func newTonePlayer(ctx *audio.Context, specs []soundSpec) (*audio.Player, error) {
+	return ctx.NewPlayerFromBytes(synthesizeTone(specs)), nil
+}
+
+func synthesizeTone(specs []soundSpec) []byte {
+	totalSamples := 0
+	for _, spec := range specs {
+		totalSamples += int(float64(sampleRate) * spec.duration)
+	}
+
+	data := make([]byte, totalSamples*4)
+	offset := 0
+	for _, spec := range specs {
+		segmentSamples := int(float64(sampleRate) * spec.duration)
+		for i := 0; i < segmentSamples; i++ {
+			progress := float64(i) / float64(segmentSamples)
+			envelope := 1.0
+			if progress < 0.08 {
+				envelope = progress / 0.08
+			} else if progress > 0.84 {
+				envelope = (1.0 - progress) / 0.16
+			}
+			if envelope < 0 {
+				envelope = 0
+			}
+
+			value := math.Sin(2*math.Pi*spec.frequency*float64(i)/sampleRate) * spec.volume * envelope
+			sample := int16(value * math.MaxInt16)
+			binary.LittleEndian.PutUint16(data[offset:], uint16(sample))
+			binary.LittleEndian.PutUint16(data[offset+2:], uint16(sample))
+			offset += 4
+		}
+	}
+	return data
+}
+
+func (a *app) playAudioEvents() {
+	if a.lastPhase == game.PhaseShowing && a.state.Phase == game.PhaseShowing &&
+		a.state.LitPad >= 0 && a.state.LitPad != a.lastLitPad {
+		a.playPlayer(a.padSounds[a.state.LitPad])
+	}
+
+	if a.lastPhase != game.PhaseShowing && a.state.Phase == game.PhaseShowing && a.state.LitPad >= 0 {
+		a.playPlayer(a.padSounds[a.state.LitPad])
+	}
+
+	if a.lastPhase != game.PhaseGameOver && a.state.Phase == game.PhaseGameOver {
+		a.playPlayer(a.gameOver)
+	}
+
+	a.lastLitPad = a.state.LitPad
+	a.lastPhase = a.state.Phase
+}
+
+func (a *app) playPlayer(player *audio.Player) {
+	if player == nil {
+		return
+	}
+	player.Pause()
+	if err := player.Rewind(); err != nil {
+		return
+	}
+	player.Play()
 }
 
 func padLabel(pad int) string {

--- a/speedpads/go.mod
+++ b/speedpads/go.mod
@@ -7,6 +7,7 @@ require github.com/hajimehoshi/ebiten/v2 v2.9.3
 require (
 	github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 // indirect
 	github.com/ebitengine/hideconsole v1.0.0 // indirect
+	github.com/ebitengine/oto/v3 v3.4.0 // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/jezek/xgb v1.1.1 // indirect
 	golang.org/x/sync v0.17.0 // indirect

--- a/speedpads/go.sum
+++ b/speedpads/go.sum
@@ -2,6 +2,8 @@ github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1 h1:+kz5iTT3L7u
 github.com/ebitengine/gomobile v0.0.0-20250923094054-ea854a63cce1/go.mod h1:lKJoeixeJwnFmYsBny4vvCJGVFc3aYDalhuDsfZzWHI=
 github.com/ebitengine/hideconsole v1.0.0 h1:5J4U0kXF+pv/DhiXt5/lTz0eO5ogJ1iXb8Yj1yReDqE=
 github.com/ebitengine/hideconsole v1.0.0/go.mod h1:hTTBTvVYWKBuxPr7peweneWdkUwEuHuB3C1R/ielR1A=
+github.com/ebitengine/oto/v3 v3.4.0 h1:br0PgASsEWaoWn38b2Goe7m1GKFYfNgnsjSd5Gg+/bQ=
+github.com/ebitengine/oto/v3 v3.4.0/go.mod h1:IOleLVD0m+CMak3mRVwsYY8vTctQgOM0iiL6S7Ar7eI=
 github.com/ebitengine/purego v0.9.0 h1:mh0zpKBIXDceC63hpvPuGLiJ8ZAa3DfrFTudmfi8A4k=
 github.com/ebitengine/purego v0.9.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/hajimehoshi/ebiten/v2 v2.9.3 h1:i2xYZ7GUk7/Bwa4CUxI/cZq+zrDrYCHGgwHLO61/Dok=


### PR DESCRIPTION
## Summary
- add synthesized audio cues for pad flashes during sequence playback
- add a separate descending game-over cue
- keep player button presses silent so only the game playback is audible

## Why
Speedpads is playable now, but the sequence playback is still visual-only. This slice adds simple beeper-style feedback without bringing in external assets or changing the player-input sound behavior.

## Impact
- each pad has a distinct tone when the game flashes it during playback
- game over now has its own audio cue
- player presses remain silent, which keeps the audio focused on the sequence and failure states

## Testing
- `cd speedpads && GOCACHE=/tmp/codex-gocache go test ./...`
- `cd speedpads && GOCACHE=/tmp/codex-gocache go build ./cmd/speedpads`

Refs #123.