### PR TITLE
docs(speedpads): refresh README usage

### DIFF
--- a/speedpads/README.md
+++ b/speedpads/README.md
@@ -1,6 +1,6 @@
 # Speedpads
 
-Speedpads is a Speden Spelit inspired memory-speed game built with Ebiten. The current implementation includes the core show/input loop, deterministic sequence generation, round-to-round speed ramping, and watchdog timeouts for stalled input.
+Speedpads is a Speden Spelit inspired memory-speed game built with Ebiten. The current version includes a playable four-pad loop, deterministic sequence generation, playback audio cues, a game-over tone, round-to-round speed ramping, and watchdog timeouts for stalled input.
 
 ## Installation
 
@@ -35,14 +35,20 @@ go run ./cmd/speedpads
 ```
 
 Controls:
-- `Space` to start
+- `Space` or `Enter` to start
 - `D`, `F`, `J`, `K` for the four pads
 - `R` to restart after game over
 - `Esc` to quit
 
+Gameplay notes:
+- The game replays the full sequence each round and then waits for your input.
+- If you already know the sequence, you can start pressing during playback. The first press cuts the remaining playback and switches immediately to input mode.
+- The game plays distinct tones when it flashes sequence pads and a separate descending tone on game over.
+- Your own button presses stay silent so only the playback and failure cues make sound.
+
 ## Testing & Coverage
 
-The gameplay tests cover the deterministic sequence, show phase, input phase, watchdog timeout, and round progression behavior.
+The gameplay tests cover deterministic sequence generation, show-to-input transitions, early-input handling, watchdog timeout, and round progression behavior.
 
 ```bash
 cd speedpads
@@ -60,5 +66,6 @@ make cover
 ## Development notes
 
 - Rendering uses [Ebiten v2](https://ebiten.org/) to match the existing GUI games in this repository.
+- Audio cues are synthesized in code with Ebiten's audio package; there are no external sound assets.
 - Core game rules live in `internal/game`.
 - Follow the shared repository conventions in [../agents.md](../agents.md).


### PR DESCRIPTION
## Summary
- refresh the Speedpads README so it matches the current merged gameplay and controls
- document the playback interruption rule, audio cues, and current command examples
- update the development notes to mention synthesized in-code audio instead of external sound assets

## Why
The earlier README still described the pre-audio, pre-polish version of Speedpads. After the gameplay and audio slices merged, the remaining work for issue #123 was to make the docs reflect the real user experience and developer setup.

## Impact
- users get accurate controls and gameplay behavior
- audio behavior is now documented clearly
- the app issue can be closed with the planned v1 scope complete

## Testing
- cd speedpads && GOCACHE=/tmp/codex-gocache go build ./cmd/speedpads
- cd speedpads && GOCACHE=/tmp/codex-gocache go test ./...

Closes #123.